### PR TITLE
Fix PHP 8.x deprecations and incompatibilities

### DIFF
--- a/ceo-import.php
+++ b/ceo-import.php
@@ -27,14 +27,14 @@ function ceo_breakdown_comic_filename($filename, $import_date_format, $import_fi
 	
 	foreach (array('[0-9]{4}', '[0-9]{2}') as $year_pattern) {
 		$new_pattern = ceo_transform_date_string($import_date_format, array("Y" => $year_pattern, "m" => '[0-9]{2}', "d" => '[0-9]{2}'));
-		if (@preg_match("#^(${new_pattern})(.*)\.[^\.]+$#", $filename, $matches) > 0) {
+		if (@preg_match("#^({$new_pattern})(.*)\.[^\.]+$#", $filename, $matches) > 0) {
 			list($all, $date, $title) = $matches;
 			
 			if (strtotime($date) === false) { return false; }
 			$converted_title = ucwords(trim(preg_replace('/[\-\_]/', ' ', $title)));
 			$date = date($import_date_format, strtotime($date));
 			
-			if (is_numeric($converted_title)) {	$converted_title = "Title: ${converted_title}"; }
+			if (is_numeric($converted_title)) {	$converted_title = "Title: {$converted_title}"; }
 			return compact('filename', 'date', 'title', 'converted_title');
 		}
 	}

--- a/functions/admin-meta.php
+++ b/functions/admin-meta.php
@@ -83,7 +83,7 @@ function ceo_chapters_sortable_columns( $columns ) {
 	return $columns;
 }
 
-function ceo_chapters_add_column_value($empty = '', $custom_column, $term_id) {
+function ceo_chapters_add_column_value($empty, $custom_column, $term_id) {
 	switch ($custom_column) {
 		case 'id':
 			echo $term_id;

--- a/functions/casthover.php
+++ b/functions/casthover.php
@@ -69,9 +69,9 @@ function ceo_add_characters_hovercards($post_characters) {
 //widget code below here
 class ceo_casthover_reference_widget extends WP_Widget {
 	
-	function ceo_casthover_reference_widget() {
+	function __construct() {
 		$widget_ops = array('classname' => __CLASS__, 'description' => __('Creates a grid of avatars for characters in the current comic.', 'comiceasel') );
-		$this->WP_Widget(__CLASS__, __('Comic Easel - Cast Hover', 'comiceasel'), $widget_ops);
+		parent::__construct(__CLASS__, __('Comic Easel - Cast Hover', 'comiceasel'), $widget_ops);
 	}
 	
 	function widget($args, $instance) {

--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -166,7 +166,7 @@ function ceo_display_comic($size = 'full') {
 		}
 	}
 	$output = '';
-	if (ceo_the_above_html()) $output .= html_entity_decode(ceo_the_above_html())."\r\n";
+	if (ceo_the_above_html()) $output .= html_entity_decode(ceo_the_above_html(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)."\r\n";
 
 	if ($flash_file = get_post_meta($post->ID, "flash_file", true)) {
 		$output .= ceo_display_flash_comic($post, $flash_file);
@@ -187,7 +187,7 @@ function ceo_display_comic($size = 'full') {
 			$output .= ceo_display_featured_image_comic($size);
 		}
 	}	
-	if (ceo_the_below_html()) $output .= html_entity_decode(ceo_the_below_html())."\r\n";
+	if (ceo_the_below_html()) $output .= html_entity_decode(ceo_the_below_html(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)."\r\n";
 	if ($output) { 
 		return apply_filters('ceo_comics_display_comic', $output);
 	} else

--- a/widgets/comic-calendar.php
+++ b/widgets/comic-calendar.php
@@ -45,7 +45,7 @@ function ceo_get_calendar($initial = true, $echo = true, $taxonomy = 'post') {
 
 	// Quick check. If we have no posts at all, abort!
 	if ( !$posts ) {
-		$gotsome = $wpdb->get_var("SELECT 1 as test FROM $wpdb->posts WHERE post_type = '${taxonomy}' AND post_status = 'publish' LIMIT 1");
+		$gotsome = $wpdb->get_var("SELECT 1 as test FROM $wpdb->posts WHERE post_type = '{$taxonomy}' AND post_status = 'publish' LIMIT 1");
 		if ( !$gotsome ) {
 			$cache[ $key ] = '';
 			wp_cache_set( 'get_comic_calendar', $cache, 'calendar' );
@@ -67,7 +67,7 @@ function ceo_get_calendar($initial = true, $echo = true, $taxonomy = 'post') {
 		// We need to get the month from MySQL
 		$thisyear = ''.intval(substr($m, 0, 4));
 		$d = (($w - 1) * 7) + 6; //it seems MySQL's weeks disagree with PHP's
-		$thismonth = $wpdb->get_var("SELECT DATE_FORMAT((DATE_ADD('${thisyear}0101', INTERVAL $d DAY) ), '%m')");
+		$thismonth = $wpdb->get_var("SELECT DATE_FORMAT((DATE_ADD('{$thisyear}0101', INTERVAL $d DAY) ), '%m')");
 	} elseif ( !empty($m) ) {
 		$thisyear = ''.intval(substr($m, 0, 4));
 		if ( strlen($m) < 6 )
@@ -85,14 +85,14 @@ function ceo_get_calendar($initial = true, $echo = true, $taxonomy = 'post') {
 	$previous = $wpdb->get_row("SELECT DISTINCT MONTH(post_date) AS month, YEAR(post_date) AS year
 		FROM $wpdb->posts
 		WHERE post_date < '$thisyear-$thismonth-01'
-		AND post_type = '${taxonomy}' AND post_status = 'publish'
+		AND post_type = '{$taxonomy}' AND post_status = 'publish'
 			ORDER BY post_date DESC
 			LIMIT 1");
 	$next = $wpdb->get_row("SELECT	DISTINCT MONTH(post_date) AS month, YEAR(post_date) AS year
 		FROM $wpdb->posts
 		WHERE post_date >	'$thisyear-$thismonth-01'
 		AND MONTH( post_date ) != MONTH( '$thisyear-$thismonth-01' )
-		AND post_type = '${taxonomy}' AND post_status = 'publish'
+		AND post_type = '{$taxonomy}' AND post_status = 'publish'
 			ORDER	BY post_date ASC
 			LIMIT 1");
 
@@ -147,7 +147,7 @@ function ceo_get_calendar($initial = true, $echo = true, $taxonomy = 'post') {
 	$dayswithposts = $wpdb->get_results("SELECT DISTINCT DAYOFMONTH(post_date)
 		FROM $wpdb->posts WHERE MONTH(post_date) = '$thismonth'
 		AND YEAR(post_date) = '$thisyear'
-		AND post_type = '${taxonomy}' AND post_status = 'publish'
+		AND post_type = '{$taxonomy}' AND post_status = 'publish'
 		AND post_date < '" . current_time('mysql') . '\'', ARRAY_N);
 	if ( $dayswithposts ) {
 		foreach ( (array) $dayswithposts as $daywith ) {


### PR DESCRIPTION
Hi! With PHP 7.4 long past EOL, many hosts are moving webcomic sites onto PHP 8.1+, so I ran the plugin through `php -l` on PHP 8.5 and a PHPCompatibility (`testVersion 8.0-`) scan. The good news: the codebase is already nearly clean. This PR fixes everything the scan surfaced — 12 lines across 5 files, no functional changes intended:

- **`ceo-import.php`, `widgets/comic-calendar.php`** — replace `${var}` string interpolation with `{$var}` (deprecated since PHP 8.2).
- **`functions/admin-meta.php`** — remove the default value from `$empty` in `ceo_chapters_add_column_value()`; declaring an optional parameter before a required one is deprecated since PHP 8.0, and the default was implicitly ignored anyway.
- **`functions/displaycomic.php`** — pass explicit flags (`ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401`) to `html_entity_decode()`; the default changed in PHP 8.1, so this pins the modern behavior consistently across PHP versions.
- **`functions/casthover.php`** — convert the PHP4-style constructor to `__construct()` (PHP4-style constructors were removed in PHP 8.0). Note this file appears to be unloaded legacy code (the loaded copy is `widgets/casthover.php`, which was already modernized), so alternatively it could simply be deleted — happy to update the PR that way if you prefer.

After these changes, all 32 PHP files pass `php -l` on PHP 8.5.8 and a PHPCompatibility scan targeting PHP 8.0+ with zero errors and zero warnings.

Thanks for continuing to maintain Comic Easel!

🤖 Generated with [Claude Code](https://claude.com/claude-code)