### PR TITLE
Bump version to 1.17

### DIFF
--- a/comiceasel.php
+++ b/comiceasel.php
@@ -3,7 +3,7 @@
 Plugin Name: Comic Easel
 Plugin URI: http://comiceasel.com
 Description: Comic Easel allows you to incorporate a WebComic using the WordPress Media Library functionality with Navigation into almost all WordPress themes. With just a few modifications of adding injection do_action locations into a theme, you can have the theme of your choice display and manage a webcomic.
-Version: 1.15
+Version: 1.17
 Author: Philip M. Hofer (Frumph)
 Author URI: http://frumph.net/
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: Frumph, Shadchamp
 Tags: comiceasel, easel, webcomic, comic, webcomic
 Requires at least: 4.8.2
 Tested up to: 6.8.3
-Stable tag: 1.16
+Stable tag: 1.17
 Text Domain: comiceasel
 Donate link: http://frumph.net
 License: GPLv3 or later
@@ -129,6 +129,11 @@ The comic navigation widget is only seen if you have the comic sidebar's enabled
 
 
 == Changelog ==
+
+= 1.17 =
+* PHP 8.x compatibility: replaced deprecated ${var} string interpolation, fixed optional-before-required parameter declaration, converted PHP4-style constructor, pinned html_entity_decode() flags
+* All files now pass PHP 8.5 lint and a PHPCompatibility scan targeting PHP 8.0+
+* Fixed Version header in comiceasel.php, which still reported 1.15 in the 1.16 release
 
 = 1.16 =
 * Patched CVE-2024-31092


### PR DESCRIPTION
Follow-up to #36 per your comments — thanks for the merge and the collaborator invite!

- `comiceasel.php` `Version:` header → **1.17**. Note it still said **1.15**: it was never bumped for 1.16, so sites running 1.16 self-report as 1.15 to WordPress. Going straight to 1.17 (rather than 1.16.1) sidesteps that confusion.
- `readme.txt` `Stable tag:` → 1.17, plus a changelog entry covering the PHP 8.x fixes from #36.

Once this is merged I'll publish a **Comic Easel 1.17** release (tag `1.17`, matching the existing tag style) with an attached `comic-easel-1.17.zip` whose top-level folder is `comic-easel/` — so it can be unzipped straight over `wp-content/plugins/` or installed via the dashboard uploader without creating a versioned folder name, which the auto-generated source zips do.

Holding off on the readme `Contributors:` / wordpress.org username for now — will sort out a wp.org account first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)