### PR TITLE
Add test infrastructure: PHPUnit harness, CI, and scoped PHPCS

### DIFF
--- a/.github/scripts/phpcs-added-lines.py
+++ b/.github/scripts/phpcs-added-lines.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Report only the PHPCS findings that sit on lines a pull request added.
+
+This plugin predates the WordPress coding standards by roughly a decade, so its files carry
+hundreds of pre-existing findings each. Running PHPCS over whole files would therefore fail
+every pull request that touches legacy code, whether or not it made anything worse -- and a
+job that is always red is a job nobody reads.
+
+Filtering to added lines keeps the signal: a finding is reported when this change introduced
+it, and the historical backlog stays a separate, deliberate piece of work.
+
+Even scoped this way it is advisory, not a gate. Some of what it reports cannot reasonably
+be fixed: the sniffs cannot see through `apply_filters()` to an escaper inside it, cannot
+know that an interpolated ORDER BY direction was whitelisted, and object to the
+`$before_title` / `$after_title` arguments that every WordPress widget emits. Failing a build
+on those would mean scattering `phpcs:ignore` annotations through unrelated changes, so the
+job reports and moves on. Pass --strict to exit non-zero instead.
+
+Usage: phpcs-added-lines.py [--strict] <phpcs-report.json> <unified-diff>
+"""
+
+import collections
+import json
+import os
+import re
+import sys
+
+HUNK = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+
+
+def added_lines(diff_path):
+    """Map each file to the set of line numbers this diff adds to it."""
+    added = collections.defaultdict(set)
+    current = None
+    new_line = 0
+    with open(diff_path, encoding='utf-8', errors='replace') as fh:
+        for line in fh:
+            if line.startswith('+++ '):
+                path = line[4:].strip()
+                current = None if path == '/dev/null' else re.sub(r'^b/', '', path)
+                continue
+            if line.startswith('@@'):
+                m = HUNK.match(line)
+                if m:
+                    new_line = int(m.group(1))
+                continue
+            if current is None:
+                continue
+            if line.startswith('+'):
+                added[current].add(new_line)
+                new_line += 1
+            elif not line.startswith('-'):
+                # Context line. With --unified=0 these are rare, but count them anyway so
+                # the line numbering stays correct if the diff is ever generated with context.
+                new_line += 1
+    return added
+
+
+def main():
+    args = [a for a in sys.argv[1:] if a != '--strict']
+    strict = '--strict' in sys.argv[1:]
+    if len(args) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    report_path, diff_path = args
+    if not os.path.exists(report_path) or os.path.getsize(report_path) == 0:
+        print('PHPCS produced no report; nothing to check.')
+        return 0
+
+    with open(report_path, encoding='utf-8', errors='replace') as fh:
+        report = json.load(fh)
+
+    added = added_lines(diff_path)
+
+    def to_repo_path(reported_path):
+        """Map a path in the PHPCS report onto the repo-relative path used by the diff.
+
+        PHPCS reports absolute paths. Those normally sit under the working directory, but
+        not always -- so fall back to matching the longest path suffix that the diff knows
+        about, rather than silently treating every finding as untouched and reporting a
+        false all-clear.
+        """
+        rel = os.path.relpath(reported_path, os.getcwd())
+        if not rel.startswith('..'):
+            return rel
+        norm = reported_path.replace(os.sep, '/')
+        for candidate in added:
+            if norm.endswith('/' + candidate) or norm == candidate:
+                return candidate
+        return rel
+
+    reported = 0
+    suppressed = 0
+    for abs_path, data in report.get('files', {}).items():
+        rel = to_repo_path(abs_path)
+        touched = added.get(rel, set())
+        for msg in data.get('messages', []):
+            if msg.get('type') != 'ERROR':
+                continue
+            if msg.get('line') in touched:
+                reported += 1
+                print('{}:{}:{}  {}\n    {}'.format(
+                    rel, msg.get('line'), msg.get('column'), msg.get('source'), msg.get('message')))
+            else:
+                suppressed += 1
+
+    print()
+    if suppressed:
+        print('{} pre-existing finding(s) on untouched lines were not reported.'.format(suppressed))
+    if reported:
+        print('{} finding(s) on lines this change adds -- worth a look, but note that some '
+              'are unavoidable; see the header of this script.'.format(reported))
+        return 1 if strict else 0
+    print('No PHPCS findings on added lines.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Syntax check across every PHP version we claim to support. This is the cheapest useful
+  # signal in the repo: the plugin's recent history is PHP 8 compatibility work, and until
+  # now nothing verified it on more than one interpreter.
+  lint-php:
+    name: php -l (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - name: Lint every PHP file
+        run: |
+          find . -name '*.php' -not -path './vendor/*' -print0 \
+            | xargs -0 -n1 -P4 php -l
+
+  test:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.2', '8.3', '8.4' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
+      - name: Run tests
+        run: composer test
+
+  # Scoped to the files a pull request actually touches. An unscoped run reports thousands
+  # of pre-existing findings on decade-old code, which would make this job permanently red
+  # and train everyone to ignore it.
+  phpcs:
+    name: PHPCS (changed files)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
+      - name: Determine changed PHP files
+        id: changed
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE" ]; then BASE="$(git rev-parse HEAD~1 2>/dev/null || echo '')"; fi
+          if [ -z "$BASE" ]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+          else
+            FILES="$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.php' | grep -v '^vendor/' | tr '\n' ' ')"
+            echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run PHPCS on changed files
+        run: |
+          if [ -z "${{ steps.changed.outputs.files }}" ]; then
+            echo "No PHP files changed; nothing to check."
+            exit 0
+          fi
+          ./vendor/bin/phpcs ${{ steps.changed.outputs.files }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,24 @@ jobs:
       - name: Run tests
         run: composer test
 
-  # Scoped to the files a pull request actually touches. An unscoped run reports thousands
-  # of pre-existing findings on decade-old code, which would make this job permanently red
-  # and train everyone to ignore it.
+  # Scoped to the LINES a pull request actually adds, not merely the files it touches.
+  #
+  # Scoping by file is not enough here. This plugin predates the WordPress coding standards
+  # by about a decade, and its files carry hundreds of pre-existing findings apiece -- so a
+  # per-file run goes red the moment a PR edits a legacy file, regardless of whether the PR
+  # made anything worse. A job that is red by default is a job everyone learns to scroll
+  # past, which is worse than not having it.
+  #
+  # Reporting only on added lines means the job stays quiet unless someone introduces a new
+  # finding, and cleaning up the historical ones stays an independent choice.
+  #
+  # Advisory, not a gate. Some of what it reports cannot reasonably be fixed -- the sniffs
+  # cannot see through apply_filters() to an escaper inside it, cannot know an interpolated
+  # ORDER BY direction was whitelisted, and object to the $before_title/$after_title that
+  # every WordPress widget emits. Gating on those would mean scattering phpcs:ignore
+  # annotations through unrelated changes. Add --strict below to make it blocking.
   phpcs:
-    name: PHPCS (changed files)
+    name: PHPCS (advisory, changed lines)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,21 +77,28 @@ jobs:
           coverage: none
       - name: Install dependencies
         run: composer update --no-interaction --prefer-dist
-      - name: Determine changed PHP files
-        id: changed
+      - name: Report PHPCS findings on added lines
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
-          if [ -z "$BASE" ]; then BASE="$(git rev-parse HEAD~1 2>/dev/null || echo '')"; fi
-          if [ -z "$BASE" ]; then
-            echo "files=" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE" ]; then
+            # Compare against the merge base, so a base branch that has moved on since the
+            # pull request opened does not drag unrelated commits into the diff.
+            BASE="$(git merge-base "$BASE" HEAD)"
           else
-            FILES="$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.php' | grep -v '^vendor/' | tr '\n' ' ')"
-            echo "files=$FILES" >> "$GITHUB_OUTPUT"
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || true)"
           fi
-      - name: Run PHPCS on changed files
-        run: |
-          if [ -z "${{ steps.changed.outputs.files }}" ]; then
+          if [ -z "$BASE" ]; then
+            echo "No base commit to compare against; skipping."
+            exit 0
+          fi
+          echo "Comparing against $BASE"
+          git diff --unified=0 "$BASE" HEAD -- '*.php' > /tmp/pr.diff
+          FILES="$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.php' | grep -v '^vendor/' || true)"
+          if [ -z "$FILES" ]; then
             echo "No PHP files changed; nothing to check."
             exit 0
           fi
-          ./vendor/bin/phpcs ${{ steps.changed.outputs.files }}
+          echo "$FILES" | tr '\n' ' '; echo
+          # -q so the progress output does not corrupt the JSON report.
+          echo "$FILES" | xargs ./vendor/bin/phpcs -q --report=json > /tmp/phpcs.json || true
+          python3 .github/scripts/phpcs-added-lines.py /tmp/phpcs.json /tmp/pr.diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/vendor/
+/.phpunit.cache/
+/.phpcs-cache
+phpunit.xml
+phpcs.xml
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+	"name": "frumph/comic-easel",
+	"description": "Comic Easel — post webcomics to your WordPress theme.",
+	"type": "wordpress-plugin",
+	"license": "GPL-3.0-or-later",
+	"require": {
+		"php": ">=7.4"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^11.5",
+		"squizlabs/php_codesniffer": "^3.10",
+		"wp-coding-standards/wpcs": "^3.1",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"scripts": {
+		"test": "phpunit",
+		"lint": "phpcs",
+		"lint:fix": "phpcbf",
+		"lint:php": "find . -name '*.php' -not -path './vendor/*' -not -path './.git/*' -print0 | xargs -0 -n1 php -l"
+	}
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset name="Comic Easel">
+	<description>
+		Escaping and security sniffs for Comic Easel.
+
+		Scoped deliberately narrow. The plugin predates these standards by a decade and a
+		full WordPress-Extra run reports thousands of pre-existing findings, which would
+		bury the ones that matter. Start with the sniffs that catch the bug classes this
+		plugin has actually had -- unescaped output, unprepared SQL, missing nonce and
+		capability checks -- and widen later if anyone has the appetite.
+	</description>
+
+	<file>.</file>
+	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/tests/*</exclude-pattern>
+	<exclude-pattern>/js/jscalendar-*/*</exclude-pattern>
+
+	<arg name="extensions" value="php"/>
+	<arg name="colors"/>
+	<arg value="sp"/>
+
+	<config name="minimum_wp_version" value="4.8"/>
+	<config name="testVersion" value="7.4-"/>
+
+	<rule ref="WordPress.Security"/>
+	<rule ref="WordPress.DB.PreparedSQL"/>
+	<rule ref="WordPress.DB.PreparedSQLPlaceholders"/>
+	<rule ref="WordPress.WP.EnqueuedResources"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+		bootstrap="tests/bootstrap.php"
+		cacheDirectory=".phpunit.cache"
+		colors="true"
+		failOnWarning="true"
+		failOnNotice="true"
+		failOnDeprecation="true"
+		beStrictAboutOutputDuringTests="true">
+	<testsuites>
+		<testsuite name="comic-easel">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/ArchiveQueryTest.php
+++ b/tests/ArchiveQueryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * The archive listing queries — functions/shortcodes.php
+ *
+ * These functions build SQL by hand, and their $order and $chapter arguments arrive from
+ * [comic-archive] shortcode attributes. A spy $wpdb records the SQL, which lets us assert
+ * on the query text with no database at all — the plugin's queries use MySQL-only date
+ * functions, so a SQLite test database would misreport them anyway.
+ *
+ * Characterization only: these assert the shape of the query, which does not change when
+ * the arguments start being sanitised. The injection assertions ship with that fix.
+ */
+class ArchiveQueryTest extends CE_TestCase {
+
+	/** @var CE_WPDB_Spy */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/shortcodes.php' );
+		$this->wpdb = $this->useWpdbSpy();
+		// Pin the year so the functions do not go looking for the newest comic.
+		$_GET['archive_year'] = '2020';
+	}
+
+	protected function tearDown(): void {
+		unset( $_GET['archive_year'] );
+		parent::tearDown();
+	}
+
+	public function testByYearWithoutChapterQueriesPublishedComics() {
+		ceo_archive_list_by_year( false, 'ASC', 0 );
+		$sql = $this->wpdb->last();
+		$this->assertStringContainsString( 'DISTINCT YEAR(post_date)', $sql );
+		$this->assertStringContainsString( "post_type='comic'", $sql );
+		$this->assertStringContainsString( "post_status = 'publish'", $sql );
+	}
+
+	public function testByYearWithChapterJoinsTheChaptersTaxonomy() {
+		ceo_archive_list_by_year( false, 'ASC', 5 );
+		$sql = $this->wpdb->last();
+		$this->assertStringContainsString( 'term_relationships', $sql );
+		$this->assertStringContainsString( 'term_taxonomy', $sql );
+		$this->assertStringContainsString( "taxonomy = 'chapters'", $sql );
+	}
+
+	public function testByAllYearsWithChapterJoinsTheChaptersTaxonomy() {
+		ceo_archive_list_by_all_years( false, 'ASC', 5 );
+		$this->assertStringContainsString( "taxonomy = 'chapters'", $this->wpdb->last() );
+	}
+
+	/**
+	 * Table names must come from $wpdb rather than being hardcoded, or the query silently
+	 * returns nothing on any site whose prefix is not the default.
+	 */
+	public function testArchiveQueriesUseTheConfiguredTablePrefix() {
+		$this->wpdb->posts = 'xyz_posts';
+		ceo_archive_list_by_year( false, 'ASC', 0 );
+		$sql = $this->wpdb->last();
+		$this->assertStringContainsString( 'xyz_posts', $sql );
+		$this->assertStringNotContainsString( 'wp_posts', $sql );
+	}
+
+	public function testByYearRendersTheSelectedYearHeading() {
+		$out = ceo_archive_list_by_year( false, 'ASC', 0 );
+		$this->assertStringContainsString( '2020', $out );
+		$this->assertStringContainsString( 'archive-yearlist', $out );
+	}
+
+	/**
+	 * archive_year comes from the query string and is cast to int before use, so a
+	 * non-numeric value must not reach the output.
+	 */
+	public function testArchiveYearFromQueryStringIsCastToInteger() {
+		$_GET['archive_year'] = '2020<script>alert(1)</script>';
+		$out = ceo_archive_list_by_year( false, 'ASC', 0 );
+		$this->assertStringNotContainsString( '<script>', $out );
+		$this->assertStringContainsString( '2020', $out );
+	}
+}

--- a/tests/CE_TestCase.php
+++ b/tests/CE_TestCase.php
@@ -1,0 +1,60 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base case: resets the stub state between tests and offers a few helpers for loading
+ * plugin files once per process.
+ */
+abstract class CE_TestCase extends TestCase {
+
+	/** @var array<string,bool> plugin files already required in this process */
+	private static $loaded = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+		CE_Test_State::reset();
+	}
+
+	/**
+	 * Require a plugin file, relative to the plugin root, at most once per process.
+	 */
+	protected static function loadPluginFile( $relative ) {
+		if ( isset( self::$loaded[ $relative ] ) ) {
+			return;
+		}
+		self::$loaded[ $relative ] = true;
+		require_once CE_PLUGIN_DIR . '/' . $relative;
+	}
+
+	/**
+	 * Install a fresh $wpdb spy as the global and return it.
+	 */
+	protected function useWpdbSpy() {
+		$spy             = new CE_WPDB_Spy();
+		$GLOBALS['wpdb'] = $spy;
+		return $spy;
+	}
+
+	/**
+	 * Set the global $post to a lightweight stand-in. The functions under test only ever
+	 * read ->ID and ->post_author, so a real WP_Post is unnecessary.
+	 */
+	protected function setGlobalPost( $id = 1, $author = 0 ) {
+		$post               = new stdClass();
+		$post->ID           = $id;
+		$post->post_author  = $author;
+		$post->post_type    = 'comic';
+		$post->post_status  = 'publish';
+		$GLOBALS['post']    = $post;
+		return $post;
+	}
+
+	protected function setPostMeta( $post_id, $key, $value ) {
+		CE_Test_State::$post_meta[ $post_id . ':' . $key ] = $value;
+	}
+
+	protected function grantCap( $user_id, $cap ) {
+		CE_Test_State::$user_caps[ $user_id . ':' . $cap ] = true;
+	}
+}

--- a/tests/CharacterListTest.php
+++ b/tests/CharacterListTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ceo_get_character_list() — functions/shortcodes.php
+ *
+ * Backs [cast-page chapter=N]. Takes an untrusted shortcode attribute and builds SQL from
+ * it, so it is worth pinning what the query is supposed to select.
+ *
+ * Note there is deliberately no assertion here that the table names come from $wpdb: on
+ * master this function hardcodes the default prefix, and the test for that ships with the
+ * commit that fixes it.
+ */
+class CharacterListTest extends CE_TestCase {
+
+	/** @var CE_WPDB_Spy */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/shortcodes.php' );
+		$this->wpdb = $this->useWpdbSpy();
+	}
+
+	public function testReturnsFalseWhenNoCharactersFound() {
+		$this->wpdb->result = array();
+		$this->assertFalse( ceo_get_character_list( 5 ) );
+	}
+
+	public function testReturnsTheRowsWhenCharactersExist() {
+		$row              = new stdClass();
+		$row->tag         = 'hero';
+		$this->wpdb->result = array( $row );
+		$this->assertSame( array( $row ), ceo_get_character_list( 5 ) );
+	}
+
+	public function testQuerySelectsCharacterNamesForPublishedComicsInAChapter() {
+		ceo_get_character_list( 5 );
+		$sql = $this->wpdb->last();
+		$this->assertStringContainsString( "t1.taxonomy = 'chapters'", $sql );
+		$this->assertStringContainsString( "t2.taxonomy = 'characters'", $sql );
+		$this->assertStringContainsString( "p1.post_status = 'publish'", $sql );
+		$this->assertStringContainsString( "p2.post_status = 'publish'", $sql );
+		$this->assertStringContainsString( 'p1.ID = p2.ID', $sql );
+	}
+
+	public function testChapterArgumentReachesTheQuery() {
+		ceo_get_character_list( 42 );
+		$this->assertStringContainsString( '42', $this->wpdb->last() );
+	}
+}

--- a/tests/HarnessTest.php
+++ b/tests/HarnessTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Proves the harness itself works: that plugin files can be loaded against the stubs, and
+ * that the three stubs the other tests depend on behave the way WordPress does.
+ *
+ * If this file fails, treat every other assertion in the suite as unreliable.
+ */
+class HarnessTest extends CE_TestCase {
+
+	public function testPluginFilesLoadAgainstStubs() {
+		self::loadPluginFile( 'functions/shortcodes.php' );
+		self::loadPluginFile( 'functions/displaycomic.php' );
+		self::loadPluginFile( 'widgets/bf_adwidget.php' );
+		self::loadPluginFile( 'widgets/navigation.php' );
+
+		$this->assertTrue( function_exists( 'ceo_the_transcript' ) );
+		$this->assertTrue( function_exists( 'ceo_get_character_list' ) );
+		$this->assertTrue( class_exists( 'ceo_bf_adwidget' ) );
+		$this->assertTrue( class_exists( 'ceo_comic_navigation_widget' ) );
+	}
+
+	/**
+	 * esc_html()/esc_attr() must NOT re-encode existing entities; esc_textarea() must.
+	 * Several tests distinguish correct from incorrect behaviour purely on this, so if the
+	 * stubs get it wrong those tests silently stop meaning anything.
+	 */
+	public function testEscapingStubsMirrorWordPressDoubleEncodeSemantics() {
+		$this->assertSame( '&lt;b&gt;', esc_html( '&lt;b&gt;' ), 'esc_html must not double-encode' );
+		$this->assertSame( '&lt;b&gt;', esc_attr( '&lt;b&gt;' ), 'esc_attr must not double-encode' );
+		$this->assertSame( '&amp;lt;b&amp;gt;', esc_textarea( '&lt;b&gt;' ), 'esc_textarea must double-encode' );
+
+		$this->assertSame( '&lt;b&gt;', esc_html( '<b>' ) );
+		$this->assertSame( '&quot;x&quot;', esc_attr( '"x"' ) );
+	}
+
+	public function testKsesStubRecordsRatherThanFilters() {
+		$out = wp_kses_post( '<script>x</script>' );
+		$this->assertSame( CE_KSES_SENTINEL . '<script>x</script>', $out );
+		$this->assertSame( array( '<script>x</script>' ), CE_Test_State::$kses_calls );
+	}
+
+	public function testFilterStubIsOverridable() {
+		$this->assertSame( 'default', apply_filters( 'some_tag', 'default' ) );
+		CE_Test_State::$filters['some_tag'] = 'overridden';
+		$this->assertSame( 'overridden', apply_filters( 'some_tag', 'default' ) );
+	}
+
+	public function testTranslationStubIsOverridable() {
+		$this->assertSame( 'Original', __( 'Original', 'comiceasel' ) );
+		CE_Test_State::$translations['Original'] = 'Origineel';
+		$this->assertSame( 'Origineel', __( 'Original', 'comiceasel' ) );
+	}
+
+	public function testEscUrlStubRejectsDisallowedSchemes() {
+		$this->assertSame( '', esc_url( 'javascript:alert(1)' ) );
+		$this->assertSame( '', esc_url_raw( 'javascript:alert(1)' ) );
+		$this->assertSame( 'https://example.test/x', esc_url_raw( 'https://example.test/x' ) );
+	}
+
+	public function testWpdbSpyRecordsPreparedSql() {
+		$wpdb = $this->useWpdbSpy();
+		$sql  = $wpdb->prepare( 'SELECT * FROM t WHERE id = %d AND name = %s', '7 OR 1=1', "o'brien" );
+		$this->assertSame( "SELECT * FROM t WHERE id = 7 AND name = 'o\\'brien'", $sql );
+		$this->assertTrue( $wpdb->sawSql( 'id = 7' ) );
+	}
+
+	public function testStateResetsBetweenTests() {
+		$this->assertSame( array(), CE_Test_State::$kses_calls );
+		$this->assertSame( 'UTF-8', get_option( 'blog_charset' ) );
+	}
+}

--- a/tests/TranscriptTest.php
+++ b/tests/TranscriptTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * ceo_the_transcript() — functions/shortcodes.php
+ *
+ * Characterization tests. These assert behaviour that holds regardless of how the
+ * transcript is escaped on output, so they stay green while the escaping work lands.
+ * The escaping assertions themselves ship with the commit that adds the escaping.
+ */
+class TranscriptTest extends CE_TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/shortcodes.php' );
+		$this->setGlobalPost( 1 );
+	}
+
+	private function withTranscript( $value ) {
+		$this->setPostMeta( 1, 'transcript', $value );
+	}
+
+	public function testReturnsNullWhenNoTranscriptStored() {
+		$this->assertNull( ceo_the_transcript( 'raw' ) );
+	}
+
+	/**
+	 * The guard is !empty(), so the string "0" is indistinguishable from no transcript at
+	 * all. Pinned deliberately: it is surprising, it predates this work, and a future
+	 * change to the guard should have to notice it.
+	 */
+	public function testTranscriptOfLiteralZeroIsTreatedAsAbsent() {
+		$this->withTranscript( '0' );
+		$this->assertNull( ceo_the_transcript( 'raw' ) );
+	}
+
+	/**
+	 * The switch has no default arm, so an unrecognised display mode falls through and the
+	 * function returns nothing. [transcript display=html] therefore renders silently empty.
+	 */
+	public function testUnknownDisplayModeReturnsNull() {
+		$this->withTranscript( 'Panel one.' );
+		$this->assertNull( ceo_the_transcript( 'html' ) );
+	}
+
+	public function testRawModeReturnsTheTranscript() {
+		$this->withTranscript( "Panel one.\nPanel two." );
+		$this->assertStringContainsString( 'Panel one.', ceo_the_transcript( 'raw' ) );
+		$this->assertStringContainsString( 'Panel two.', ceo_the_transcript( 'raw' ) );
+	}
+
+	/**
+	 * nl2br() is applied after whatever escaping is in force, so the <br /> must be live
+	 * markup in the output rather than an escaped literal.
+	 */
+	public function testBrModeConvertsNewlinesToLiveMarkup() {
+		$this->withTranscript( "one\ntwo" );
+		$out = ceo_the_transcript( 'br' );
+		$this->assertStringContainsString( '<br />', $out );
+	}
+
+	public function testStyledModeWrapsTranscriptInTheExpanderMarkup() {
+		$this->withTranscript( 'Panel one.' );
+		$out = ceo_the_transcript( 'styled' );
+		$this->assertStringContainsString( 'transcript-border', $out );
+		$this->assertStringContainsString( 'transcript-content', $out );
+		$this->assertStringContainsString( 'Panel one.', $out );
+	}
+
+	/**
+	 * Display must be stable: a transcript stored the way the plugin's save handler stores
+	 * it -- through esc_textarea() -- must render back as exactly those bytes, so that what
+	 * the author typed is what the reader sees, on this render and every later one.
+	 *
+	 * The case that matters is an author who typed a literal entity. esc_textarea() stores
+	 * "&lt;b&gt;" as "&amp;lt;b&amp;gt;". An escape that declines to re-encode existing
+	 * entities -- which is what esc_html() does, since it passes $double_encode = false --
+	 * gives back "&lt;b&gt;" instead, one level short. Repeat that on each save and the
+	 * author's literal text decays into a live <b> tag.
+	 */
+	#[DataProvider( 'authoredTextProvider' )]
+	public function testRenderingATranscriptIsStableAcrossSaves( $typed ) {
+		$stored = esc_textarea( $typed );
+		$this->withTranscript( $stored );
+		$this->assertSame(
+			$stored,
+			ceo_the_transcript( 'raw' ),
+			'Rendering must return the stored bytes unchanged, or encoding is lost on each save'
+		);
+	}
+
+	public static function authoredTextProvider() {
+		return array(
+			'markup the author wants shown as text' => array( '<b>bold</b>' ),
+			'an entity the author typed literally'  => array( '&lt;b&gt;' ),
+			'a bare ampersand'                      => array( 'Tom & Jerry' ),
+			'an ampersand the author escaped'       => array( 'Tom &amp; Jerry' ),
+			'quotes'                                => array( 'she said "hi"' ),
+		);
+	}
+}

--- a/tests/WidgetSettingsTest.php
+++ b/tests/WidgetSettingsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Widget update() methods — widgets/bf_adwidget.php, widgets/navigation.php
+ *
+ * These decide what gets persisted from the widget admin form, so they are the storage half
+ * of the escaping story. Characterization only: assertions here hold regardless of which
+ * sanitiser each field ends up using.
+ */
+class WidgetSettingsTest extends CE_TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'widgets/bf_adwidget.php' );
+		self::loadPluginFile( 'widgets/navigation.php' );
+	}
+
+	/** Every key the navigation widget's update() reads, so no test trips an undefined key. */
+	private function navInstance( array $overrides = array() ) {
+		$checkboxes = array(
+			'previous_chap', 'next_chap', 'first_in', 'last_in', 'previous_in', 'next_in',
+			'first', 'last', 'previous', 'next', 'random', 'archives', 'comments',
+			'comictitle', 'comicchapter', 'imageurl', 'buycomic',
+		);
+		$text = array(
+			'archive_path', 'previous_chap_title', 'next_chap_title', 'first_in_title',
+			'last_in_title', 'previous_in_title', 'next_in_title', 'first_title',
+			'last_title', 'previous_title', 'next_title', 'random_title',
+			'archives_title', 'comments_title', 'buycomic_title',
+		);
+		$instance = array();
+		foreach ( $checkboxes as $key ) {
+			$instance[ $key ] = '1';
+		}
+		foreach ( $text as $key ) {
+			$instance[ $key ] = '';
+		}
+		return array_merge( $instance, $overrides );
+	}
+
+	public function testBfWidgetStripsMarkupFromTheDivId() {
+		$widget = new ceo_bf_adwidget();
+		$out    = $widget->update(
+			array( 'title' => 'Ad', 'divID' => '<b>slot</b>', 'center' => '1' ),
+			array()
+		);
+		$this->assertStringNotContainsString( '<', $out['divID'] );
+		$this->assertStringNotContainsString( '>', $out['divID'] );
+	}
+
+	public function testBfWidgetStoresCenterAsBoolean() {
+		$widget = new ceo_bf_adwidget();
+
+		$on = $widget->update( array( 'title' => '', 'divID' => 'x', 'center' => '1' ), array() );
+		$this->assertTrue( $on['center'] );
+
+		$off = $widget->update( array( 'title' => '', 'divID' => 'x', 'center' => '0' ), array() );
+		$this->assertFalse( $off['center'] );
+	}
+
+	public function testBfWidgetStripsMarkupFromTheTitle() {
+		$widget = new ceo_bf_adwidget();
+		$out    = $widget->update(
+			array( 'title' => '<em>Sponsored</em>', 'divID' => 'x', 'center' => '0' ),
+			array()
+		);
+		$this->assertSame( 'Sponsored', $out['title'] );
+	}
+
+	public function testNavigationWidgetStoresCheckboxesAsBooleans() {
+		$widget = new ceo_comic_navigation_widget();
+		$out    = $widget->update( $this->navInstance( array( 'random' => '1', 'first' => '0' ) ), array() );
+		$this->assertTrue( $out['random'] );
+		$this->assertFalse( $out['first'] );
+	}
+
+	public function testNavigationWidgetPreservesAnOrdinaryArchiveUrl() {
+		$widget = new ceo_comic_navigation_widget();
+		$out    = $widget->update( $this->navInstance( array( 'archive_path' => 'https://example.test/archive/' ) ), array() );
+		$this->assertSame( 'https://example.test/archive/', $out['archive_path'] );
+	}
+
+	public function testNavigationWidgetPreservesARelativeArchivePath() {
+		$widget = new ceo_comic_navigation_widget();
+		$out    = $widget->update( $this->navInstance( array( 'archive_path' => '/archive/' ) ), array() );
+		$this->assertSame( '/archive/', $out['archive_path'] );
+	}
+
+	public function testNavigationWidgetKeepsLinkLabelsAsText() {
+		$widget = new ceo_comic_navigation_widget();
+		$out    = $widget->update( $this->navInstance( array( 'first_title' => '&laquo; First' ) ), array() );
+		// Whatever escaping is applied on save must survive a round trip through the form
+		// without gaining a level of encoding each time.
+		$this->assertSame( $out['first_title'], $widget->update( $this->navInstance( array( 'first_title' => $out['first_title'] ) ), array() )['first_title'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPUnit bootstrap for Comic Easel.
+ *
+ * WordPress is not loaded. See tests/stubs.php for the rationale and for the stubs the
+ * tests depend on.
+ */
+
+// Plugin files guard themselves with `if (!defined('ABSPATH')) exit;`, so this has to be
+// defined before any of them are required.
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+define( 'CE_PLUGIN_DIR', dirname( __DIR__ ) );
+
+require_once __DIR__ . '/stubs.php';
+
+/**
+ * ceo_pluginfo() is the plugin's own config accessor. It lives in comiceasel.php, which
+ * does far too much at load time to require in a unit test, so it is stubbed here and
+ * driven from CE_Test_State::$pluginfo.
+ */
+if ( ! function_exists( 'ceo_pluginfo' ) ) {
+	function ceo_pluginfo( $which = null ) {
+		if ( null === $which ) {
+			return CE_Test_State::$pluginfo;
+		}
+		return array_key_exists( $which, CE_Test_State::$pluginfo ) ? CE_Test_State::$pluginfo[ $which ] : '';
+	}
+}
+
+/**
+ * Plugin-local navigation helpers, stubbed so the archive listings can be called without
+ * dragging in functions/navigation.php and its query dependencies. Not under test here.
+ */
+if ( ! function_exists( 'ceo_get_last_comic' ) ) {
+	function ceo_get_last_comic( $in_same_chapter = false ) {
+		return null;
+	}
+}
+
+if ( ! function_exists( 'ceo_get_first_comic' ) ) {
+	function ceo_get_first_comic( $in_same_chapter = false ) {
+		return null;
+	}
+}
+
+require_once __DIR__ . '/CE_TestCase.php';

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -1,0 +1,99 @@
+# Manual test setup
+
+The unit suite in `tests/` covers the plugin's logic without WordPress. It cannot cover the
+template and admin-screen code, which has no function boundary to test — the settings forms,
+the comic meta boxes, the widget forms, the admin list columns. Those need a real WordPress.
+
+This is the recipe, written down because most of it is non-obvious and every item below is a
+trap that makes a working feature look broken.
+
+## Getting a WordPress to test against
+
+No Docker or MySQL required:
+
+1. Unpack WordPress core somewhere disposable.
+2. Add the official [`sqlite-database-integration`](https://wordpress.org/plugins/sqlite-database-integration/)
+   plugin and copy its `db.copy` to `wp-content/db.php` as its readme describes.
+3. Serve with `php -S localhost:8080` from the WordPress root.
+
+SQLite is fine for admin screens, meta boxes, widgets and escaping. It is **not** reliable
+for this plugin's raw SQL: the calendar and archive queries use MySQL-only date functions
+(`YEAR`, `DATE_ADD`, `DATE_FORMAT`, `DAYOFMONTH`). Use MySQL if those are what you are
+testing, or rely on `tests/ArchiveQueryTest.php`, which asserts the emitted SQL directly.
+
+## Installing the plugin
+
+- The directory **must** be named `comic-easel`. `widgets/casthover.php` hardcodes
+  `plugins_url('comic-easel/css/casthover.css')`, so a renamed folder loses that widget's
+  CSS and JS.
+- **Activate through the Plugins screen.** Activation runs
+  `ALTER TABLE wp_terms ADD menu_order`, and a `get_terms_orderby` filter rewrites
+  `orderby=menu_order` to `t.menu_order`. Without that column, every chapter-ordered query
+  errors and silently returns nothing.
+- Use a **classic** theme such as Twenty Twenty-One. Block themes break the classic widgets
+  screen, and the archive-thumbnail injection is gated on `in_the_loop()`, which core's Query
+  Loop block does not set.
+- Re-save Settings → Permalinks after activating, and again after changing any slug option.
+
+## Fixture content
+
+- **2 chapters, each with a non-zero Order.** Order defaults to 0, and 0 makes
+  `[comic-archive list=4]` render empty and chapter prev/next navigation do nothing.
+- 2 characters, 1 location.
+- **4 published comics, each with a featured image.** The featured image *is* the comic —
+  without one, the comic renders as nothing but an HTML comment.
+- One future-dated comic (for the Scheduled Posts widget), one draft and one
+  password-protected comic (both should be refused by `[buycomic]`).
+- Leave `refer-only` **empty**. Any value in it hides the comic from every visitor whose
+  referrer does not match exactly.
+- To exercise escaping, seed `transcript`, `comic-hovertext` and `comic-html-above` with
+  values containing `<b>`, `&lt;b&gt;`, a double quote and an apostrophe. Seed some of them
+  through the **Custom Fields** panel as well as through the plugin's meta boxes: the comic
+  post type declares `custom-fields` support and these keys are not protected, so the two
+  routes store values in different shapes and a display bug can show up in one but not the
+  other.
+
+## Options worth knowing about
+
+Set on the Config page, and verify on the **Debug** page — that screen dumps the whole
+config array and is the quickest assertion target for any option write.
+
+- `disable_related_comics` defaults to **on**, so the related-comics hook looks broken until
+  you turn it off.
+- `enable_transcripts_in_comic_posts` **on** makes the `[transcript]` shortcode return
+  nothing. The two are mutually exclusive by design.
+- `[buycomic]` needs `?id=<comic_id>` in the URL; a bare `[buycomic]` page renders empty. It
+  is gated on `buy_comic_sell_print` / `buy_comic_sell_original`, not on `enable_buy_comic`
+  (that option only controls the "Buy!" nav links).
+- `enable_chapter_in_url` puts a literal `%chapters%` in the permalink of any comic that has
+  no chapter term.
+- All four plugin admin pages require `edit_theme_options`, so an Editor-role account sees
+  the Comics menu but none of Config, Monetize, Debug or Import.
+
+## Seeing a comic actually render
+
+The plugin displays comics through action hooks a theme has to fire. It never fires them
+itself, so on a stock theme **no comic wrapper, navigation or hovertext appears at all** —
+you see only the theme's own featured image. That is expected, not a bug.
+
+The minimum test theme is a classic theme whose `single.php` calls
+`do_action('comic-area');`, plus `add_theme_support('post-thumbnails')` in `functions.php`
+(without it the comic editor has no Featured Image box). Do **not** declare
+`post-formats` support: the blog-post renderer branches on it and calls
+`get_template_part('content','comic')`, which no stock theme provides, so that hook silently
+renders nothing.
+
+Reachable with no theme support at all, via shortcodes on an ordinary page:
+`[comic-archive list=2]`, `[cast-page]`, `[showcomic]`, `[comic-archive-dropdown]`, and
+`[buycomic]` with `?id=N`.
+
+## The PayPal endpoint
+
+`POST /?ceopaypalipn` talks to PayPal directly, with the hostname written into the code, so
+there is no supported way to exercise it against a local stub. Testing it means either
+editing that hostname in a scratch copy or using a PayPal sandbox account.
+
+## Always
+
+Run with `WP_DEBUG` and `WP_DEBUG_LOG` on, and treat any notice or warning originating in a
+plugin file as a finding.

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -1,0 +1,536 @@
+<?php
+/**
+ * WordPress stubs for the Comic Easel unit tests.
+ *
+ * These tests deliberately do NOT boot WordPress. The functions under test depend only on
+ * their arguments plus a small set of WordPress helpers, so stubbing those helpers gives
+ * fast, dependency-free tests of the logic that matters.
+ *
+ * Three of these stubs have to be faithful or the tests they support are worthless:
+ *
+ *  - esc_html()/esc_attr() call _wp_specialchars() with $double_encode = FALSE, so they
+ *    leave text that already looks like an entity alone. esc_textarea() double-encodes.
+ *    Most of the escaping tests probe exactly that difference, so a naive
+ *    htmlspecialchars() stub would give the wrong answer and the tests would lie.
+ *  - wp_kses_post() is a RECORDER returning a sentinel, not a reimplementation. The
+ *    assertions that matter are "was filtering applied", not "what did it strip".
+ *  - apply_filters() passes through by default but is overridable, because the filters
+ *    are the seams the PayPal tests hang on.
+ *
+ * State is held in CE_Test_State and must be reset between tests (the base test case in
+ * tests/CE_TestCase.php does that automatically).
+ */
+
+class CE_Test_State {
+	/** @var array<string,mixed> option name => value */
+	public static $options = array();
+	/** @var array<string,mixed> "postid:metakey" => value */
+	public static $post_meta = array();
+	/** @var array<string,bool> "userid:cap" => bool */
+	public static $user_caps = array();
+	/** @var array<string,mixed> filter tag => value to return */
+	public static $filters = array();
+	/** @var array<string,string> msgid => translation */
+	public static $translations = array();
+	/** @var array<string,mixed> ceo_pluginfo key => value */
+	public static $pluginfo = array();
+	/** @var mixed value returned by wp_remote_post() */
+	public static $http_response = array();
+	/** @var array recorded wp_remote_post() calls */
+	public static $http_requests = array();
+	/** @var array recorded wp_kses_post() inputs */
+	public static $kses_calls = array();
+	/** @var array recorded wp_mail() calls */
+	public static $mail_calls = array();
+	/** @var array recorded update_post_meta() calls */
+	public static $meta_writes = array();
+
+	public static function reset() {
+		self::$options = array( 'blog_charset' => 'UTF-8' );
+		self::$post_meta = array();
+		self::$user_caps = array();
+		self::$filters = array();
+		self::$translations = array();
+		self::$pluginfo = array();
+		self::$http_response = array();
+		self::$http_requests = array();
+		self::$kses_calls = array();
+		self::$mail_calls = array();
+		self::$meta_writes = array();
+	}
+}
+
+/* -------------------------------------------------------------------------- *
+ * Escaping — must mirror WordPress's double_encode semantics. See header.
+ * -------------------------------------------------------------------------- */
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8', false );
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8', false );
+	}
+}
+
+if ( ! function_exists( 'esc_textarea' ) ) {
+	function esc_textarea( $text ) {
+		// Note the missing 4th argument: htmlspecialchars() defaults to double_encode = true,
+		// which is what WordPress's esc_textarea() does too.
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_js' ) ) {
+	function esc_js( $text ) {
+		return addslashes( (string) $text );
+	}
+}
+
+/**
+ * Approximation of esc_url(). The behaviour the tests rely on is that a disallowed scheme
+ * yields an empty string and that ampersands are entity-encoded.
+ */
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $url, $protocols = null ) {
+		$url = (string) $url;
+		if ( '' === $url ) {
+			return '';
+		}
+		$allowed = null === $protocols
+			? array( 'http', 'https', 'mailto', 'ftp', 'ftps', 'news', 'irc', 'tel' )
+			: $protocols;
+		if ( preg_match( '#^([a-z0-9+.-]+):#i', $url, $m ) && ! in_array( strtolower( $m[1] ), $allowed, true ) ) {
+			return '';
+		}
+		$url = str_replace( array( '"', "'", '<', '>' ), '', $url );
+		return str_replace( '&amp;', '&#038;', htmlspecialchars( $url, ENT_NOQUOTES, 'UTF-8', false ) );
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url, $protocols = null ) {
+		$url = (string) $url;
+		if ( '' === $url ) {
+			return '';
+		}
+		$allowed = null === $protocols
+			? array( 'http', 'https', 'mailto', 'ftp', 'ftps', 'news', 'irc', 'tel' )
+			: $protocols;
+		if ( preg_match( '#^([a-z0-9+.-]+):#i', $url, $m ) && ! in_array( strtolower( $m[1] ), $allowed, true ) ) {
+			return '';
+		}
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		$str = strip_tags( (string) $str );
+		$str = preg_replace( '/[\r\n\t ]+/', ' ', $str );
+		return trim( str_replace( "\0", '', $str ) );
+	}
+}
+
+if ( ! function_exists( 'sanitize_html_class' ) ) {
+	function sanitize_html_class( $class, $fallback = '' ) {
+		$sanitized = preg_replace( '/[^A-Za-z0-9_-]/', '', (string) $class );
+		return '' === $sanitized ? $fallback : $sanitized;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+	}
+}
+
+/**
+ * Recorder, not a reimplementation. Returns a sentinel so a test can assert that filtering
+ * was applied without depending on what kses would actually have stripped.
+ */
+define( 'CE_KSES_SENTINEL', 'KSES:' );
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $data ) {
+		CE_Test_State::$kses_calls[] = $data;
+		return CE_KSES_SENTINEL . $data;
+	}
+}
+
+/* -------------------------------------------------------------------------- *
+ * Options, meta, capabilities, filters — all test-driven.
+ * -------------------------------------------------------------------------- */
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		return array_key_exists( $name, CE_Test_State::$options ) ? CE_Test_State::$options[ $name ] : $default;
+	}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $name, $value, $autoload = null ) {
+		CE_Test_State::$options[ $name ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $name ) {
+		unset( CE_Test_State::$options[ $name ] );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $post_id, $key = '', $single = false ) {
+		$k = $post_id . ':' . $key;
+		if ( ! array_key_exists( $k, CE_Test_State::$post_meta ) ) {
+			return $single ? '' : array();
+		}
+		return CE_Test_State::$post_meta[ $k ];
+	}
+}
+
+if ( ! function_exists( 'update_post_meta' ) ) {
+	function update_post_meta( $post_id, $key, $value, $prev = '' ) {
+		CE_Test_State::$post_meta[ $post_id . ':' . $key ] = $value;
+		CE_Test_State::$meta_writes[] = array( $post_id, $key, $value );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( $user, $capability, ...$args ) {
+		$id = is_object( $user ) ? $user->ID : (int) $user;
+		return ! empty( CE_Test_State::$user_caps[ $id . ':' . $capability ] );
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value = null, ...$args ) {
+		return array_key_exists( $tag, CE_Test_State::$filters ) ? CE_Test_State::$filters[ $tag ] : $value;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return array_key_exists( $text, CE_Test_State::$translations ) ? CE_Test_State::$translations[ $text ] : $text;
+	}
+}
+
+if ( ! function_exists( '_e' ) ) {
+	function _e( $text, $domain = 'default' ) {
+		echo __( $text, $domain );
+	}
+}
+
+if ( ! function_exists( '_x' ) ) {
+	function _x( $text, $context, $domain = 'default' ) {
+		return __( $text, $domain );
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $text, $domain = 'default' ) {
+		return esc_html( __( $text, $domain ) );
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return is_array( $value ) ? array_map( 'wp_unslash', $value ) : stripslashes( (string) $value );
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.test' . $path;
+	}
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+	function add_query_arg( ...$args ) {
+		if ( is_array( $args[0] ) ) {
+			$params = $args[0];
+			$url    = isset( $args[1] ) ? $args[1] : '';
+		} else {
+			$params = array( $args[0] => $args[1] );
+			$url    = isset( $args[2] ) ? $args[2] : '';
+		}
+		$sep = false === strpos( $url, '?' ) ? '?' : '&';
+		return $url . $sep . http_build_query( $params );
+	}
+}
+
+/* -------------------------------------------------------------------------- *
+ * HTTP — wp_remote_post() is test-driven and records what it was sent, which is how the
+ * IPN tests assert the notification is echoed back verbatim.
+ * -------------------------------------------------------------------------- */
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public $message;
+		public function __construct( $code = '', $message = '' ) {
+			$this->message = $message;
+		}
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_remote_post' ) ) {
+	function wp_remote_post( $url, $args = array() ) {
+		CE_Test_State::$http_requests[] = array( 'url' => $url, 'args' => $args );
+		return CE_Test_State::$http_response;
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	function wp_remote_retrieve_response_code( $response ) {
+		return isset( $response['response']['code'] ) ? $response['response']['code'] : '';
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	function wp_remote_retrieve_body( $response ) {
+		return isset( $response['body'] ) ? $response['body'] : '';
+	}
+}
+
+if ( ! function_exists( 'wp_mail' ) ) {
+	function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
+		CE_Test_State::$mail_calls[] = compact( 'to', 'subject', 'message' );
+		return true;
+	}
+}
+
+/* -------------------------------------------------------------------------- *
+ * Hook registration — no-ops, so plugin files can simply be require'd.
+ * -------------------------------------------------------------------------- */
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_action' ) ) {
+	function remove_action( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_shortcode' ) ) {
+	function add_shortcode( $tag, $callback ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'shortcode_atts' ) ) {
+	function shortcode_atts( $pairs, $atts, $shortcode = '' ) {
+		$atts = (array) $atts;
+		$out  = array();
+		foreach ( $pairs as $name => $default ) {
+			$out[ $name ] = array_key_exists( $name, $atts ) ? $atts[ $name ] : $default;
+		}
+		return $out;
+	}
+}
+
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( $args = array() ) {
+		return array();
+	}
+}
+
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post = 0 ) {
+		return 'https://example.test/?p=' . ( is_object( $post ) ? $post->ID : (int) $post );
+	}
+}
+
+if ( ! function_exists( 'get_the_title' ) ) {
+	function get_the_title( $post = 0 ) {
+		return 'Title';
+	}
+}
+
+if ( ! function_exists( 'get_the_time' ) ) {
+	function get_the_time( $format = '', $post = null ) {
+		return '2020-01-01';
+	}
+}
+
+if ( ! function_exists( 'get_post_time' ) ) {
+	function get_post_time( $format = 'U', $gmt = false, $post = null, $translate = false ) {
+		return '2020';
+	}
+}
+
+if ( ! function_exists( 'wp_cache_get' ) ) {
+	function wp_cache_get( $key, $group = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_cache_set' ) ) {
+	function wp_cache_set( $key, $data, $group = '', $expire = 0 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'register_activation_hook' ) ) {
+	function register_activation_hook( $file, $callback ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+	function register_deactivation_hook( $file, $callback ) {
+		return true;
+	}
+}
+
+/* -------------------------------------------------------------------------- *
+ * Widgets
+ * -------------------------------------------------------------------------- */
+
+if ( ! class_exists( 'WP_Widget' ) ) {
+	class WP_Widget {
+		public $id_base;
+		public $name;
+		public function __construct( $id_base = '', $name = '', $widget_options = array(), $control_options = array() ) {
+			$this->id_base = $id_base;
+			$this->name    = $name;
+		}
+		public function get_field_id( $field ) {
+			return $this->id_base . '-' . $field;
+		}
+		public function get_field_name( $field ) {
+			return $this->id_base . '[' . $field . ']';
+		}
+	}
+}
+
+/* -------------------------------------------------------------------------- *
+ * $wpdb spy — records the SQL it is handed so tests can assert on the query text
+ * without a database. This is what stands in for MySQL when checking that untrusted
+ * shortcode attributes never reach the SQL string.
+ * -------------------------------------------------------------------------- */
+
+class CE_WPDB_Spy {
+	public $posts              = 'wp_posts';
+	public $terms              = 'wp_terms';
+	public $term_relationships = 'wp_term_relationships';
+	public $term_taxonomy      = 'wp_term_taxonomy';
+	public $prefix             = 'wp_';
+
+	/** @var string[] every SQL string handed to prepare() or a get_*() method */
+	public $queries = array();
+	/** @var mixed value the next get_col()/get_results()/get_var()/get_row() returns */
+	public $result = array();
+
+	public function prepare( $query, ...$args ) {
+		// Close enough to $wpdb::prepare for assertion purposes: %d becomes an integer,
+		// %s becomes a single-quoted escaped string.
+		$i = 0;
+		$out = preg_replace_callback(
+			'/%[dsf]/',
+			function ( $m ) use ( &$i, $args ) {
+				$arg = array_key_exists( $i, $args ) ? $args[ $i ] : '';
+				$i++;
+				if ( '%d' === $m[0] ) {
+					return (string) (int) $arg;
+				}
+				if ( '%f' === $m[0] ) {
+					return (string) (float) $arg;
+				}
+				return "'" . addslashes( (string) $arg ) . "'";
+			},
+			$query
+		);
+		$this->queries[] = $out;
+		return $out;
+	}
+
+	public function get_col( $query = null, $x = 0 ) {
+		if ( null !== $query ) {
+			$this->queries[] = $query;
+		}
+		return $this->result;
+	}
+
+	public function get_results( $query = null, $output = null ) {
+		if ( null !== $query ) {
+			$this->queries[] = $query;
+		}
+		return $this->result;
+	}
+
+	public function get_var( $query = null, $x = 0, $y = 0 ) {
+		if ( null !== $query ) {
+			$this->queries[] = $query;
+		}
+		return is_array( $this->result ) ? null : $this->result;
+	}
+
+	public function get_row( $query = null, $output = null, $y = 0 ) {
+		if ( null !== $query ) {
+			$this->queries[] = $query;
+		}
+		return null;
+	}
+
+	public function query( $query ) {
+		$this->queries[] = $query;
+		return true;
+	}
+
+	public function update( $table, $data, $where, ...$rest ) {
+		return 1;
+	}
+
+	/** The SQL from the most recent call. */
+	public function last() {
+		return end( $this->queries );
+	}
+
+	/** True when any recorded query contains $needle. */
+	public function sawSql( $needle ) {
+		foreach ( $this->queries as $q ) {
+			if ( false !== strpos( $q, $needle ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
A number of users of this plugin are struggling with PHP-8 incompatibilities, creating work for them, e.g. https://puckcomics.com/new-site-same-old-puck/. To help those users, I'd like to update https://wordpress.org/plugins/comic-easel/ as you (Frumph) suggested, which is currently de-listed for a (now patched) security issue. However, in order to be sufficiently diligent before asking WP to re-list it, I'd like to submit fixes for some more vulnerabilities in a few follow-up PRs.

That starts by adding some basic test infrastructure, in order to lower the review burden and likelihood that those fixes introduce new bugs.

I'm not going to submit this without a go-ahead from you, Frumph - I apologize if this creates a review burden.

---

## What's in this PR

Test infrastructure only. **No existing plugin file is modified** — this PR is purely additive (14 new files), so it cannot change how the plugin behaves.

- **`tests/` — a PHPUnit suite that runs without WordPress.** Testing a WordPress plugin normally means standing up WordPress and a database. That isn't necessary for the part that matters here: the plugin's logic depends only on its arguments plus a small set of WordPress helpers, so `tests/stubs.php` stubs those and the suite runs in milliseconds with no database, no Docker and no WordPress checkout. It also includes a `$wpdb` spy that records the SQL it is handed, which lets the queries be tested without a database at all — worth having because several of them use MySQL-only date functions.

- **Characterization tests.** These assert current behaviour, not desired behaviour. The point is that the follow-up PRs change output escaping, and the specific risk with escaping changes is that they quietly alter what users see. These pin the behaviour that must *not* change, so any drift shows up as a failing assertion rather than as a bug report later.

- **`.github/workflows/ci.yml`** — `php -l` across PHP 7.4–8.4, PHPUnit, and PHPCS. The lint matrix seemed worth having on its own: the recent work here has been PHP 8 compatibility, and `readme.txt` advertises support, but nothing has verified that across versions automatically.

- **PHPCS is advisory and scoped to changed lines.** An unscoped run reports thousands of pre-existing findings across the older code, which would make the job permanently red and train everyone to ignore it. I originally scoped it per-file, then actually ran it — which showed that isn't enough either, since these files carry hundreds of pre-existing findings apiece and the job would fail on any PR that touches a legacy file. So it now reports only on lines a PR adds, and it reports rather than blocks: some findings genuinely can't be fixed (the sniffs can't see through `apply_filters()` to an escaper inside it, can't know an interpolated `ORDER BY` direction was whitelisted, and object to the `$before_title`/`$after_title` every WP widget emits). Gating on those would mean scattering `phpcs:ignore` annotations through unrelated changes. The ruleset is deliberately narrow too (`WordPress.Security` and the prepared-SQL sniffs) rather than the full `WordPress-Extra`.

All ten jobs pass — I verified by running the workflow on a throwaway PR against my own fork first, since Actions doesn't appear to have run on this repo before. That's also how the per-file problem above surfaced.

- **`tests/manual/README.md`** — the unit suite can't reach the settings forms, meta boxes, widget forms or admin columns, since those are templates with no function to call. This documents how to exercise those by hand, including the setup details that are easy to lose an hour to (the plugin directory has to be named `comic-easel` or one widget loses its assets; activation has to go through the Plugins screen because it adds a column several queries depend on; chapter Order defaults to 0, which makes one archive mode render empty).

Happy to adjust any of it, or to drop pieces you'd rather not carry.

