### PR TITLE
Escaping and input validation fixes (stacked on #38)

### DIFF
--- a/ceo-adconfig.php
+++ b/ceo-adconfig.php
@@ -4,7 +4,10 @@
 <?php
 $tab = '';
 if (isset($_GET['tab'])) $tab = sanitize_key($_GET['tab']);
-if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'comiceasel_reset') {
+if (isset($_POST['action']) && $_POST['action'] == 'comiceasel_reset') {
+	if (!current_user_can('edit_theme_options'))
+		wp_die(__('You do not have permission to reset these settings.','comiceasel'));
+	check_admin_referer('update-options');
 	delete_option('comiceasel-config');
 	global $ceo_pluginfo;
 	$ceo_pluginfo = array();

--- a/ceo-adconfig.php
+++ b/ceo-adconfig.php
@@ -4,9 +4,13 @@
 <?php
 $tab = '';
 if (isset($_GET['tab'])) $tab = sanitize_key($_GET['tab']);
-if (isset($_POST['action']) && $_POST['action'] == 'comiceasel_reset') {
+// Read the submitted action once. The forms on this page post it, but a request carrying
+// only a nonce does not, so the reads below were emitting an undefined-key warning apiece
+// on PHP 8. Action names are plain keys, so sanitize_key() is the right shape for it.
+$action = isset($_POST['action']) ? sanitize_key(wp_unslash($_POST['action'])) : '';
+if ($action == 'comiceasel_reset') {
 	if (!current_user_can('edit_theme_options'))
-		wp_die(__('You do not have permission to reset these settings.','comiceasel'));
+		wp_die(esc_html__('You do not have permission to reset these settings.','comiceasel'));
 	check_admin_referer('update-options');
 	delete_option('comiceasel-config');
 	global $ceo_pluginfo;
@@ -18,7 +22,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'comiceasel_reset') {
 }
 		$ceo_options = get_option('comiceasel-config');
 		if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-options') ) {
-		if ($_REQUEST['action'] == 'ceo_save_afmain') {
+		if ($action == 'ceo_save_afmain') {
 			if (!empty($_REQUEST['bf_adinfo']) && empty($ceo_options['bf_adinf'])) {
 				$path = get_home_path();
 				$url = 'https://www.lfg.co/ads.txt';

--- a/ceo-config.php
+++ b/ceo-config.php
@@ -7,7 +7,10 @@
 <?php
 $tab = '';
 if (isset($_GET['tab'])) $tab = sanitize_key($_GET['tab']);
-if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'comiceasel_reset') {
+if (isset($_POST['action']) && $_POST['action'] == 'comiceasel_reset') {
+	if (!current_user_can('edit_theme_options'))
+		wp_die(__('You do not have permission to reset these settings.','comiceasel'));
+	check_admin_referer('update-options');
 	delete_option('comiceasel-config');
 	global $ceo_pluginfo;
 	$ceo_pluginfo = array();

--- a/ceo-config.php
+++ b/ceo-config.php
@@ -7,9 +7,13 @@
 <?php
 $tab = '';
 if (isset($_GET['tab'])) $tab = sanitize_key($_GET['tab']);
-if (isset($_POST['action']) && $_POST['action'] == 'comiceasel_reset') {
+// Read the submitted action once. The forms on this page post it, but a request carrying
+// only a nonce does not, so the reads below were emitting an undefined-key warning apiece
+// on PHP 8. Action names are plain keys, so sanitize_key() is the right shape for it.
+$action = isset($_POST['action']) ? sanitize_key(wp_unslash($_POST['action'])) : '';
+if ($action == 'comiceasel_reset') {
 	if (!current_user_can('edit_theme_options'))
-		wp_die(__('You do not have permission to reset these settings.','comiceasel'));
+		wp_die(esc_html__('You do not have permission to reset these settings.','comiceasel'));
 	check_admin_referer('update-options');
 	delete_option('comiceasel-config');
 	global $ceo_pluginfo;
@@ -21,7 +25,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'comiceasel_reset') {
 }
 $ceo_options = get_option('comiceasel-config');
 if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-options') ) {
-		if ($_REQUEST['action'] == 'ceo_save_general') {
+		if ($action == 'ceo_save_general') {
 
 			foreach (array(
 				'thumbnail_size_for_rss',
@@ -60,7 +64,7 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 			update_option('comiceasel-config', $ceo_options);
 		}
 		
-		if ($_REQUEST['action'] == 'ceo_save_navigation') {
+		if ($action == 'ceo_save_navigation') {
 
 			foreach (array(
 				'graphic_navigation_directory'
@@ -93,7 +97,7 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 			update_option('comiceasel-config', $ceo_options);
 		}
 
-		if ($_REQUEST['action'] == 'ceo_save_archive') {
+		if ($action == 'ceo_save_archive') {
 
 			foreach (array(
 				'custom_post_type_slug_name',
@@ -117,7 +121,7 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 			update_option('comiceasel-config', $ceo_options);
 		}
 		
-		if ($_REQUEST['action'] == 'ceo_save_landing') {
+		if ($action == 'ceo_save_landing') {
 			foreach (array(
 				'enable_chapter_landing',
 				'enable_chapter_landing_first',
@@ -131,7 +135,7 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 			update_option('comiceasel-config', $ceo_options);
 		}
 		
-		if ($_REQUEST['action'] == 'ceo_save_buycomic') {
+		if ($action == 'ceo_save_buycomic') {
 
 			foreach (array(
 				'buy_comic_email',

--- a/ceo-debug.php
+++ b/ceo-debug.php
@@ -26,15 +26,15 @@ function ceo_check_directory($dirpath) {
 	<th colspan="3"><?php _e('System Info','comiceasel'); ?></th>
 	</tr>
 </thead>
-<tr><td>error</td><td><?php echo ceo_pluginfo('error'); ?></td></tr>
-<tr><td>base_url</td><td><?php echo ceo_pluginfo('base_url'); ?></td></tr>
-<tr><td>base_path</td><td><?php echo ceo_pluginfo('base_path'); ?><br /><?php echo ceo_check_directory('base_path'); ?></td></tr>
-<tr><td>theme_url</td><td><?php echo ceo_pluginfo('theme_url'); ?></td></tr>
-<tr><td>theme_path</td><td><?php echo ceo_pluginfo('theme_path'); ?></td></tr>
-<tr><td>style_url</td><td><?php echo ceo_pluginfo('style_url'); ?></td></tr>
-<tr><td>style_path</td><td><?php echo ceo_pluginfo('style_path'); ?></td></tr>
-<tr><td>plugin_url</td><td><?php echo ceo_pluginfo('plugin_url'); ?></td></tr>
-<tr><td>plugin_path</td><td><?php echo ceo_pluginfo('plugin_path'); ?></td></tr>
+<tr><td>error</td><td><?php echo esc_html(ceo_pluginfo('error')); ?></td></tr>
+<tr><td>base_url</td><td><?php echo esc_html(ceo_pluginfo('base_url')); ?></td></tr>
+<tr><td>base_path</td><td><?php echo esc_html(ceo_pluginfo('base_path')); ?><br /><?php echo ceo_check_directory('base_path'); ?></td></tr>
+<tr><td>theme_url</td><td><?php echo esc_html(ceo_pluginfo('theme_url')); ?></td></tr>
+<tr><td>theme_path</td><td><?php echo esc_html(ceo_pluginfo('theme_path')); ?></td></tr>
+<tr><td>style_url</td><td><?php echo esc_html(ceo_pluginfo('style_url')); ?></td></tr>
+<tr><td>style_path</td><td><?php echo esc_html(ceo_pluginfo('style_path')); ?></td></tr>
+<tr><td>plugin_url</td><td><?php echo esc_html(ceo_pluginfo('plugin_url')); ?></td></tr>
+<tr><td>plugin_path</td><td><?php echo esc_html(ceo_pluginfo('plugin_path')); ?></td></tr>
 </table>
 </div>
 <br />
@@ -53,8 +53,8 @@ function ceo_check_directory($dirpath) {
 	if ($val == '1') $val = 'True';
 ?>
 		<tr>
-			<td><?php echo $key; ?></td>
-			<td><?php echo $val; ?></td>
+			<td><?php echo esc_html($key); ?></td>
+			<td><?php echo esc_html($val); ?></td>
 		</tr>
 <?php }
 ?>

--- a/comiceasel.php
+++ b/comiceasel.php
@@ -608,6 +608,6 @@ function ceo_run_scripts() {
 function ceo_bf_add_script_to_head() {
 	$ceo_options = get_option('comiceasel-config');
 	if (isset($ceo_options['bf_adinfo']) && !empty($ceo_options['bf_adinfo'])) {
-		echo '<script type="text/javascript" src="https://thor.blindferret.media/'.ceo_pluginfo('bf_adinfo').'/jita.js?dfp=1" async defer></script>'."\r\n";
+		echo '<script type="text/javascript" src="'.esc_url('https://thor.blindferret.media/'.rawurlencode(ceo_pluginfo('bf_adinfo')).'/jita.js?dfp=1').'" async defer></script>'."\r\n";
 	}
 }

--- a/functions/admin-meta.php
+++ b/functions/admin-meta.php
@@ -128,7 +128,7 @@ function ceo_manage_comic_columns($column_name, $id) {
 			$allterms = get_the_terms( $id, 'chapters');
 			if (!empty($allterms) && !isset($allterms->errors)) {
 				foreach ($allterms as $term) {
-					$term_list_chapters[] = '<a href="'.admin_url('edit.php?post_type=comic&chapters='.$term->name).'">'.$term->name.'</a>';
+					$term_list_chapters[] = '<a href="'.esc_url(admin_url('edit.php?post_type=comic&chapters='.urlencode($term->name))).'">'.esc_html($term->name).'</a>';
 				}
 				echo join(', ', $term_list_chapters );
 			}
@@ -137,7 +137,7 @@ function ceo_manage_comic_columns($column_name, $id) {
 			$allterms = get_the_terms( $id, 'characters');
 			if (!empty($allterms) && !isset($allterms->errors)) {
 				foreach ($allterms as $term) {
-					$term_list_characters[] = '<a href="'.admin_url('edit.php?post_type=comic&characters='.$term->name).'">'.$term->name.'</a>';
+					$term_list_characters[] = '<a href="'.esc_url(admin_url('edit.php?post_type=comic&characters='.urlencode($term->name))).'">'.esc_html($term->name).'</a>';
 				}
 				echo join(', ', $term_list_characters );
 			}
@@ -146,7 +146,7 @@ function ceo_manage_comic_columns($column_name, $id) {
 			$allterms = get_the_terms( $id, 'locations');
 			if (!empty($allterms) && !isset($allterms->errors)) {
 				foreach ($allterms as $term) {
-					$term_list_locations[] = '<a href="'.admin_url('/wp-admin/edit.php?post_type=comic&locations='.$term->name).'">'.$term->name.'</a>';
+					$term_list_locations[] = '<a href="'.esc_url(admin_url('/wp-admin/edit.php?post_type=comic&locations='.urlencode($term->name))).'">'.esc_html($term->name).'</a>';
 				}
 				echo join(', ', $term_list_locations );
 			}
@@ -423,7 +423,7 @@ function ceo_edit_taxonomy_archive_overwrite() {
 			<option class="level-0" value="" <?php if ($current_selected == 'none' || empty($current_selected)) { ?>selected="selected"<?php } ?>><?php echo __('Do Not Use', 'comiceasel'); ?></option>
 	<?php
 		foreach ($terms as $term) { ?>
-			<option class="level-0" value="<?php echo $term->slug; ?>" <?php if ($current_selected == $term->slug) { ?>selected="selected"<?php } ?>><?php echo $term->name; ?></option>
+			<option class="level-0" value="<?php echo esc_attr($term->slug); ?>" <?php if ($current_selected == $term->slug) { ?>selected="selected"<?php } ?>><?php echo esc_html($term->name); ?></option>
 	<?php } ?>
 		</select>
 <?php		

--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -129,11 +129,11 @@ function ceo_display_flash_comic($post, $flash_url) {
 	if (empty($height)) $height = '380';
 	if (empty($width)) $width = '520';
 	$output = '';
-	$output .= '<object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="'.$width.'" height="'.$height.'" id="flash_comic" align="middle">'."\r\n";
-	$output .= '	<param name="movie" value="'.$flash_url.'"/>'."\r\n";
+	$output .= '<object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="'.esc_attr($width).'" height="'.esc_attr($height).'" id="flash_comic" align="middle">'."\r\n";
+	$output .= '	<param name="movie" value="'.esc_url($flash_url).'"/>'."\r\n";
 	$output .= '    <!--[if !IE]>-->'."\r\n";
-	$output .= '    <object type="application/x-shockwave-flash" data="'.$flash_url.'" width="'.$width.'" height="'.$height.'">'."\r\n";
-	$output .= '        <param name="movie" value="'.$flash_url.'"/>'."\r\n";
+	$output .= '    <object type="application/x-shockwave-flash" data="'.esc_url($flash_url).'" width="'.esc_attr($width).'" height="'.esc_attr($height).'">'."\r\n";
+	$output .= '        <param name="movie" value="'.esc_url($flash_url).'"/>'."\r\n";
 	$output .= '    <!--<![endif]-->'."\r\n";
 	$output .= ceo_display_featured_image_comic('full');
 	$output .= '        <a href="http://www.adobe.com/go/getflash">'."\r\n";

--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -37,7 +37,7 @@ function ceo_display_featured_image_comic($size = 'full') {
 			
 			if ($linkto) $next_comic = esc_url($linkto);
 			
-			if ($linkto && !$comic_has_map) $output .= '<a href="'.$linkto.'" '.$hovertext.'>';
+			if ($linkto && !$comic_has_map) $output .= '<a href="'.esc_url($linkto).'" '.$hovertext.'>';
 			
 			if ($comic_lightbox && !$linkto && !$comic_has_map) {
 				$output .= '<a href="'.$thumbnail.'" '.$hovertext.' rel="lightbox">';

--- a/functions/injections.php
+++ b/functions/injections.php
@@ -27,7 +27,7 @@ add_action('comic-blog-area', 'ceo_display_comic_post_home');
 
 function ceo_version_meta() {
 	echo apply_filters('ceo_version_meta', '<meta name="Comic-Easel" content="'.ceo_pluginfo('version').'" />'."\r\n");
-	echo apply_filters('ceo_version_meta_referrer', '<meta name="Referrer" content="'.ceo_get_referer().'" />'."\r\n");
+	echo apply_filters('ceo_version_meta_referrer', '<meta name="Referrer" content="'.esc_attr(ceo_get_referer()).'" />'."\r\n");
 }
 
 function ceo_display_edit_link() {

--- a/functions/injections.php
+++ b/functions/injections.php
@@ -130,7 +130,7 @@ function ceo_display_comic_navigation() {
 				$bpsep = '?';
 			}
 		?>
-		<td class="comic-nav"><a href="<?php echo ceo_pluginfo('buy_comic_url').$bpsep.'id='.$post->ID; ?>" class="comic-nav-base comic-nav-buycomic" title="Buy Comic"><?php _e('Buy!','comiceasel'); ?></a></td>
+		<td class="comic-nav"><a href="<?php echo esc_url(ceo_pluginfo('buy_comic_url').$bpsep.'id='.$post->ID); ?>" class="comic-nav-base comic-nav-buycomic" title="Buy Comic"><?php _e('Buy!','comiceasel'); ?></a></td>
 <?php }
 if (ceo_pluginfo('enable_comment_nav') && !wp_is_mobile()) { 
 			$commentscount = get_comments_number(); ?>

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -410,7 +410,7 @@ function ceo_archive_list_by_year($thumbnail = false, $order = 'ASC', $chapter =
 	}
 	foreach ( $years as $year ) {
 		if ($year != (0) ) {
-			$output .= '<a href="'.add_query_arg('archive_year', $year).'"><strong>'.$year.'</strong></a> | ';
+			$output .= '<a href="'.esc_url(add_query_arg('archive_year', $year)).'"><strong>'.esc_html($year).'</strong></a> | ';
 		} 
 	}
 	$output .= '</div>';

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -523,7 +523,10 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 		
 		ceo_protect();
 		$post = get_post($comicnum); // Get the post
-		if (!is_wp_error($post) && !empty($post)) { // error check make sure it got a post
+		// get_post() will happily return drafts, pending/private/trashed posts,
+		// revisions and other post types, so require that this really is public
+		// comic content before disclosing anything about it.
+		if (!is_wp_error($post) && !empty($post) && $post->post_type === 'comic' && $post->post_status === 'publish') {
 			$buy_output .= __('Comic ID','comiceasel').' #'.$comicnum."<br />\r\n";
 			$buy_output .= __('Title:','comiceasel').'&nbsp;'.get_the_title($post)."<br />\r\n";
 			if (ceo_pluginfo('buy_comic_sell_print')) {

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -530,10 +530,10 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 			$buy_output .= __('Comic ID','comiceasel').' #'.$comicnum."<br />\r\n";
 			$buy_output .= __('Title:','comiceasel').'&nbsp;'.get_the_title($post)."<br />\r\n";
 			if (ceo_pluginfo('buy_comic_sell_print')) {
-				$buy_output .= __('Print Status:','comiceasel').'&nbsp;'.$buyprint_status."<br />\r\n";
+				$buy_output .= __('Print Status:','comiceasel').'&nbsp;'.esc_html($buyprint_status)."<br />\r\n";
 			}
 			if (ceo_pluginfo('buy_comic_sell_original')) {
-				$buy_output .= __('Original Status:','comiceasel').'&nbsp;'.$buyorig_status."<br />\r\n";
+				$buy_output .= __('Original Status:','comiceasel').'&nbsp;'.esc_html($buyorig_status)."<br />\r\n";
 			}
 			$buy_output .= "<br />\r\n";
 			$buy_output .= '<table class="buytable" style="width:100%;">';

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -543,21 +543,20 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 				$buy_output .= '<td align="left" valign="top" style="width:50%;">';
 				$buy_output .= '<div class="buycomic-us-form">';
 				$buy_output .= '<h4 class="buycomic-title">Print</h4>';
-				$buy_output .= '$'.$buy_print_amount.'<br />';
+				$buy_output .= '$'.esc_html($buy_print_amount).'<br />';
 				if ($buyprint_status == __('Available','comiceasel')) {
 					$buy_output .= '<form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">';
 					$buy_output .= '<input type="hidden" name="add" value="1" />';
 					$buy_output .= '<input type="hidden" name="cmd" value="_cart" />';
-					$buy_output .= '<input type="hidden" name="notify_url" value="'.home_url().'/?ceopaypalipn">';
-					$buy_output .= '<input type="hidden" name="item_name" value="'.__('Print','comiceasel').' - '.get_the_title($post->ID).' - '.$post->ID.'" />';
+					$buy_output .= '<input type="hidden" name="notify_url" value="'.esc_url(home_url('/?ceopaypalipn')).'">';
+					$buy_output .= '<input type="hidden" name="item_name" value="'.esc_attr(__('Print','comiceasel').' - '.get_the_title($post->ID).' - '.$post->ID).'" />';
 					// Say a thank you and that transaction went through with an action
-					$url = ceo_pluginfo('buy_comic_url');
-					$url_and = (strpos($url,'?')) ? $url.'&amp;' : $url.'?';
-					$buy_output .= '<input type="hidden" name="return" value="'.$url_and.'action=thankyou&amp;id='.$comicnum.'" />';
-					$buy_output .= '<input type="hidden" name="amount" value="'.$buy_print_amount.'" />';
-					$buy_output .= '<input type="hidden" name="item_number" value="'.$comicnum.'" />';
-					$buy_output .= '<input type="hidden" name="business" value="'.ceo_pluginfo('buy_comic_email').'" />';
-					$buy_output .= '<input type="image" src="'.ceo_pluginfo('plugin_url').'images/buynow_paypal.png" name="submit32" alt="'.__('Make payments with PayPal - it is fast, free and secure!','comiceasel').'" />';
+					$return_url = add_query_arg(array('action' => 'thankyou', 'id' => $comicnum), ceo_pluginfo('buy_comic_url'));
+					$buy_output .= '<input type="hidden" name="return" value="'.esc_url($return_url).'" />';
+					$buy_output .= '<input type="hidden" name="amount" value="'.esc_attr($buy_print_amount).'" />';
+					$buy_output .= '<input type="hidden" name="item_number" value="'.esc_attr($comicnum).'" />';
+					$buy_output .= '<input type="hidden" name="business" value="'.esc_attr(ceo_pluginfo('buy_comic_email')).'" />';
+					$buy_output .= '<input type="image" src="'.esc_url(ceo_pluginfo('plugin_url').'images/buynow_paypal.png').'" name="submit32" alt="'.esc_attr(__('Make payments with PayPal - it is fast, free and secure!','comiceasel')).'" />';
 					$buy_output .= '</form>';
 				}
 				if ($buyprint_status == __('Sold','comiceasel')) {
@@ -575,21 +574,20 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 				$buy_output .= '<td align="left" valign="top" style="width:50%;">';
 				$buy_output .= '<div class="buycomic-us-form" style="width:100%;">';
 				$buy_output .= '<h4 class="buycomic-title">Original</h4>';
-				$buy_output .= '$'.$buy_print_orig_amount.'<br />';
+				$buy_output .= '$'.esc_html($buy_print_orig_amount).'<br />';
 				if ($buyorig_status == __('Available','comiceasel')) {
 					$buy_output .= '<form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">';
 					$buy_output .= '<input type="hidden" name="add" value="1" />';
 					$buy_output .= '<input type="hidden" name="cmd" value="_cart" />';
-					$buy_output .= '<input type="hidden" name="notify_url" value="'.home_url().'/?ceopaypalipn">';
-					$buy_output .= '<input type="hidden" name="item_name" value="'.__('Original','comiceasel').' - '.get_the_title($post->ID).' - '.$post->ID.'" />';
+					$buy_output .= '<input type="hidden" name="notify_url" value="'.esc_url(home_url('/?ceopaypalipn')).'">';
+					$buy_output .= '<input type="hidden" name="item_name" value="'.esc_attr(__('Original','comiceasel').' - '.get_the_title($post->ID).' - '.$post->ID).'" />';
 					// Say a thank you and that transaction went through with an action
-					$url = ceo_pluginfo('buy_comic_url');
-					$url_and = (strpos($url,'?')) ? $url.'&amp;' : $url.'?';
-					$buy_output .= '<input type="hidden" name="return" value="'.$url_and.'action=thankyou&amp;id='.$comicnum.'" />';
-					$buy_output .= '<input type="hidden" name="amount" value="'.$buy_print_orig_amount.'" />';
-					$buy_output .= '<input type="hidden" name="item_number" value="'.$comicnum.'" />';
-					$buy_output .= '<input type="hidden" name="business" value="'.ceo_pluginfo('buy_comic_email').'" />';
-					$buy_output .= '<input type="image" src="'.ceo_pluginfo('plugin_url').'images/buynow_paypal.png" name="submit32" alt="'.__('Make payments with PayPal - it is fast, free and secure!','comiceasel').'" />';
+					$return_url = add_query_arg(array('action' => 'thankyou', 'id' => $comicnum), ceo_pluginfo('buy_comic_url'));
+					$buy_output .= '<input type="hidden" name="return" value="'.esc_url($return_url).'" />';
+					$buy_output .= '<input type="hidden" name="amount" value="'.esc_attr($buy_print_orig_amount).'" />';
+					$buy_output .= '<input type="hidden" name="item_number" value="'.esc_attr($comicnum).'" />';
+					$buy_output .= '<input type="hidden" name="business" value="'.esc_attr(ceo_pluginfo('buy_comic_email')).'" />';
+					$buy_output .= '<input type="image" src="'.esc_url(ceo_pluginfo('plugin_url').'images/buynow_paypal.png').'" name="submit32" alt="'.esc_attr(__('Make payments with PayPal - it is fast, free and secure!','comiceasel')).'" />';
 					$buy_output .= '</form>';
 				}
 				if ($buyorig_status == __('Sold','comiceasel')) {

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -388,7 +388,10 @@ function ceo_the_transcript($displaymode = 'raw') {
 
 function ceo_archive_list_by_year($thumbnail = false, $order = 'ASC', $chapter = 0) {
 	global $wpdb;
-	if (isset($_GET['archive_year'])) { 
+	// $order and $chapter arrive from shortcode attributes, so they are untrusted.
+	$chapter = (int)$chapter;
+	$order = (strtoupper($order) == 'DESC') ? 'DESC' : 'ASC';
+	if (isset($_GET['archive_year'])) {
 		$archive_year = (int)esc_attr($_GET['archive_year']); 
 	} else { 
 		$latest_comic = ceo_get_last_comic(false);
@@ -400,7 +403,7 @@ function ceo_archive_list_by_year($thumbnail = false, $order = 'ASC', $chapter =
 	$output .= '<div class="archive-yearlist">| ';
 	
 	if ($chapter) {
-		$years = $wpdb->get_col("SELECT DISTINCT YEAR(post_date) FROM $wpdb->posts LEFT JOIN $wpdb->term_relationships ON ($wpdb->posts.ID = $wpdb->term_relationships.object_id) LEFT JOIN $wpdb->term_taxonomy ON ($wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id) WHERE $wpdb->posts.post_status = 'publish' AND $wpdb->term_taxonomy.taxonomy = 'chapters' AND $wpdb->term_taxonomy.term_id = ".$chapter." ORDER BY post_date ".$order);
+		$years = $wpdb->get_col($wpdb->prepare("SELECT DISTINCT YEAR(post_date) FROM $wpdb->posts LEFT JOIN $wpdb->term_relationships ON ($wpdb->posts.ID = $wpdb->term_relationships.object_id) LEFT JOIN $wpdb->term_taxonomy ON ($wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id) WHERE $wpdb->posts.post_status = 'publish' AND $wpdb->term_taxonomy.taxonomy = 'chapters' AND $wpdb->term_taxonomy.term_id = %d ORDER BY post_date ".$order, $chapter));
 	} else {
 		$years = $wpdb->get_col("SELECT DISTINCT YEAR(post_date) FROM $wpdb->posts WHERE post_status = 'publish' AND post_type='comic' ORDER BY post_date ASC");
 	}
@@ -438,12 +441,15 @@ function ceo_archive_list_by_year($thumbnail = false, $order = 'ASC', $chapter =
 
 function ceo_archive_list_by_all_years($thumbnail = false, $order = 'ASC', $chapter = 0) {
 	global $wpdb;
+	// $order and $chapter arrive from shortcode attributes, so they are untrusted.
+	$chapter = (int)$chapter;
+	$order = (strtoupper($order) == 'DESC') ? 'DESC' : 'ASC';
 	$latest_comic = ceo_get_last_comic(false);
 	$archive_year_latest = get_post_time('Y', false, $latest_comic, true);
 	$first_comic = ceo_get_first_comic(false);
 	$archive_year_first = get_post_time('Y', false, $first_comic, true);
 	if ($chapter) {
-		$years = $wpdb->get_col("SELECT DISTINCT YEAR(post_date) FROM $wpdb->posts LEFT JOIN $wpdb->term_relationships ON ($wpdb->posts.ID = $wpdb->term_relationships.object_id) LEFT JOIN $wpdb->term_taxonomy ON ($wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id) WHERE $wpdb->posts.post_status = 'publish' AND $wpdb->term_taxonomy.taxonomy = 'chapters' AND $wpdb->term_taxonomy.term_id = ".$chapter." ORDER BY post_date ".$order);
+		$years = $wpdb->get_col($wpdb->prepare("SELECT DISTINCT YEAR(post_date) FROM $wpdb->posts LEFT JOIN $wpdb->term_relationships ON ($wpdb->posts.ID = $wpdb->term_relationships.object_id) LEFT JOIN $wpdb->term_taxonomy ON ($wpdb->term_relationships.term_taxonomy_id = $wpdb->term_taxonomy.term_taxonomy_id) WHERE $wpdb->posts.post_status = 'publish' AND $wpdb->term_taxonomy.taxonomy = 'chapters' AND $wpdb->term_taxonomy.term_id = %d ORDER BY post_date ".$order, $chapter));
 	} else {
 		$years = $wpdb->get_col("SELECT DISTINCT YEAR(post_date) FROM $wpdb->posts WHERE post_status = 'publish' AND post_type='comic' ORDER BY post_date ".$order);
 	}

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -192,7 +192,7 @@ function ceo_archive_list_single($chapter = 0, $order = 'ASC', $thumbnail = 0) {
 	foreach ($qposts as $qpost) {
 		$archive_count++;
 		if ($css_alt) { $alternate = ' comic-list-alt'; $css_alt = false; } else { $alternate = ''; $css_alt=true; }		
-		$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qpost->ID).'" rel="bookmark" title="'.__('Permanent Link:','comiceasel').' '.$qpost->post_title.'">'.$qpost->post_title.'</a></span></div>';
+		$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qpost->ID).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qpost->post_title).'">'.esc_html($qpost->post_title).'</a></span></div>';
 	}
 	$output .= '</div>';
 	$output .= '<div style="clear:both;"></div></div>';
@@ -240,7 +240,7 @@ function ceo_archive_list_all($order = 'ASC', $thumbnail = 0) {
 			foreach ($qposts as $qpost) {
 				$archive_count++;
 				if ($css_alt) { $alternate = ' comic-list-alt'; $css_alt = false; } else { $alternate = ''; $css_alt=true; }
-				$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qpost->ID).'" rel="bookmark" title="'.__('Permanent Link:','comiceasel').' '.$qpost->post_title.'">'.$qpost->post_title.'</a></span></div>'."\r\n";
+				$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qpost->ID).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qpost->post_title).'">'.esc_html($qpost->post_title).'</a></span></div>'."\r\n";
 			}
 			$output .= '</div>'."\r\n";
 			$output .= '<div style="clear:both;"></div></div>'."\r\n";
@@ -291,7 +291,7 @@ function ceo_archive_list_series($thumbnail = 0) {
 					foreach ($qcposts as $qcpost) {
 						$archive_count++;
 						if ($css_alt) { $alternate = ' comic-list-alt'; $css_alt = false; } else { $alternate = ''; $css_alt=true; }		
-						$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qcpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qcpost->ID).'" rel="bookmark" title="'.__('Permanent Link:','comiceasel').' '.$qcpost->post_title.'">'.$qcpost->post_title.'</a></span></div>';
+						$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qcpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qcpost->ID).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qcpost->post_title).'">'.esc_html($qcpost->post_title).'</a></span></div>';
 					}
 					$output .= '</div>';
 					$output .= '<div style="clear:both;"></div></div>';	

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -62,7 +62,8 @@ function ceo_cast_display($character, $stats, $image) {
 // , $limit, $stats, $image, $order
 function ceo_get_character_list($chapter) {
 	global $wpdb;
-	$sql_string3 = "SELECT DISTINCT terms2.name as tag
+	// $chapter arrives from the [cast-page] shortcode attribute, so it is untrusted.
+	$sql_string3 = $wpdb->prepare("SELECT DISTINCT terms2.name as tag
 			FROM
 			wp_posts as p1
 			LEFT JOIN wp_term_relationships as r1 ON p1.ID = r1.object_ID
@@ -74,10 +75,10 @@ function ceo_get_character_list($chapter) {
 			LEFT JOIN wp_term_taxonomy as t2 ON r2.term_taxonomy_id = t2.term_taxonomy_id
 			LEFT JOIN wp_terms as terms2 ON t2.term_id = terms2.term_id
 			WHERE
-			t1.taxonomy = 'chapters' AND p1.post_status = 'publish' AND terms1.term_id = '".$chapter."' AND
+			t1.taxonomy = 'chapters' AND p1.post_status = 'publish' AND terms1.term_id = %d AND
 			t2.taxonomy = 'characters' AND p2.post_status = 'publish'
-			AND p1.ID = p2.ID";
-	
+			AND p1.ID = p2.ID", (int)$chapter);
+
 	$character_list = $wpdb->get_results($sql_string3);
 	if (!empty($character_list)) return $character_list;
 	return false;

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -526,7 +526,7 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 		// get_post() will happily return drafts, pending/private/trashed posts,
 		// revisions and other post types, so require that this really is public
 		// comic content before disclosing anything about it.
-		if (!is_wp_error($post) && !empty($post) && $post->post_type === 'comic' && $post->post_status === 'publish') {
+		if (!is_wp_error($post) && !empty($post) && $post->post_type === 'comic' && $post->post_status === 'publish' && !post_password_required($post)) {
 			$buy_output .= __('Comic ID','comiceasel').' #'.$comicnum."<br />\r\n";
 			$buy_output .= __('Title:','comiceasel').'&nbsp;'.get_the_title($post)."<br />\r\n";
 			if (ceo_pluginfo('buy_comic_sell_print')) {

--- a/monetize/afmain.php
+++ b/monetize/afmain.php
@@ -23,7 +23,7 @@
 				<tr class="alternate">
 					<th scope="row"><label for="bf_adinfo"><?php _e('Site ID:','comiceasel'); ?></label></th>
 					<td>
-						<input id="bf_adinfo" name="bf_adinfo" type="text" value="<?php echo $ceo_options['bf_adinfo']; ?>" /><br />
+						<input id="bf_adinfo" name="bf_adinfo" type="text" value="<?php echo esc_attr($ceo_options['bf_adinfo']); ?>" /><br />
 					</td>
 				</tr>				
 				<tr>

--- a/options/archive.php
+++ b/options/archive.php
@@ -53,7 +53,7 @@
 					<?php if (empty($ceo_options['custom_post_type_slug_name'])) $ceo_options['custom_post_type_slug_name'] = 'comic'; ?>
 					<th scope="row"><label for="custom_post_type_slug_name"><?php _e('Custom Post Type slug name?','comiceasel'); ?></label></th>
 					<td>
-						<input id="custom_post_type_slug_name" name="custom_post_type_slug_name" type="text" value="<?php echo $ceo_options['custom_post_type_slug_name']; ?>" /><br />
+						<input id="custom_post_type_slug_name" name="custom_post_type_slug_name" type="text" value="<?php echo esc_attr($ceo_options['custom_post_type_slug_name']); ?>" /><br />
 <?php 
 $check_term = term_exists($ceo_options['custom_post_type_slug_name']);
 if ($check_term) { ?>
@@ -73,7 +73,7 @@ if ($check_term) { ?>
 					<?php if (empty($ceo_options['chapter_type_slug_name'])) $ceo_options['chapter_type_slug_name'] = 'comic'; ?>
 					<th scope="row"><label for="chapter_type_slug_name"><?php _e('Chapter Type slug name?','comiceasel'); ?></label></th>
 					<td>
-						<input id="chapter_type_slug_name" name="chapter_type_slug_name" type="text" value="<?php echo $ceo_options['chapter_type_slug_name']; ?>" /><br />
+						<input id="chapter_type_slug_name" name="chapter_type_slug_name" type="text" value="<?php echo esc_attr($ceo_options['chapter_type_slug_name']); ?>" /><br />
 <?php 
 $check_term = term_exists($ceo_options['chapter_type_slug_name']);
 if ($check_term) { ?>
@@ -93,7 +93,7 @@ if ($check_term) { ?>
 					<?php if (empty($ceo_options['chapter_type_name_plural'])) $ceo_options['chapter_type_name_plural'] = 'chapters'; ?>
 					<th scope="row"><label for="chapter_type_name_plural"><?php _e('Chapter name plural form?','comiceasel'); ?></label></th>
 					<td>
-						<input id="chapter_type_name_plural" name="chapter_type_name_plural" type="text" value="<?php echo $ceo_options['chapter_type_name_plural']; ?>" /><br />
+						<input id="chapter_type_name_plural" name="chapter_type_name_plural" type="text" value="<?php echo esc_attr($ceo_options['chapter_type_name_plural']); ?>" /><br />
 					</td>
 					<td>
 						<?php _e('Default: "chapters" changing this will modify the description information of the plural form of what is put as the chapters slug.  For example if you change the chapters slug to "story" this would be "stories" - use lowercase.','comiceasel'); ?><br />

--- a/options/buycomic.php
+++ b/options/buycomic.php
@@ -31,7 +31,7 @@
 				<tr>
 					<th scope="row" colspan="2">
 						<label for="buy_comic_email"><?php _e('Paypal email address','comiceasel'); ?></label>
-						<input type="text" size="25" name="buy_comic_email" id="buy_comic_email" value="<?php echo $ceo_options['buy_comic_email']; ?>" />
+						<input type="text" size="25" name="buy_comic_email" id="buy_comic_email" value="<?php echo esc_attr($ceo_options['buy_comic_email']); ?>" />
 					</th>
 					<td>
 						<span style="color: #d54e21;"><?php _e('* This must be correct, you do not want other people getting your money.','comiceasel'); ?></span><br />
@@ -41,7 +41,7 @@
 				<tr class="alternate">
 					<th scope="row"colspan="2">
 						<label for="buy_comic_url"><?php _e('FULL URL of where the buy comic shortcode is. (required)','comiceasel'); ?></label>
-						<input type="text" size="25" name="buy_comic_url" id="buy_comic_url" value="<?php echo $ceo_options['buy_comic_url']; ?>" />
+						<input type="text" size="25" name="buy_comic_url" id="buy_comic_url" value="<?php echo esc_attr($ceo_options['buy_comic_url']); ?>" />
 					</th>
 					<td>
 						<span style="color: #d54e21;"><?php _e('* This must be correct, the form needs some place to go.','comiceasel'); ?></span><br />
@@ -65,7 +65,7 @@
 				<tr class="alternate">
 					<th scope="row"><label for="buy_comic_print_amount"><?php _e('Print Cost','comiceasel'); ?></label></th>
 					<td>
-						<input type="text" size="7" name="buy_comic_print_amount" id="buy_comic_print_amount" value="<?php echo $ceo_options['buy_comic_print_amount']; ?>" />
+						<input type="text" size="7" name="buy_comic_print_amount" id="buy_comic_print_amount" value="<?php echo esc_attr($ceo_options['buy_comic_print_amount']); ?>" />
 					</td>
 					<td>
 						<?php _e('How much does a print cost?','comiceasel'); ?>
@@ -83,7 +83,7 @@
 				<tr class="alternate">
 					<th scope="row"><label for="buy_comic_orig_amount"><?php _e('Original Cost','comiceasel'); ?></label></th>
 					<td>
-						<input type="text" size="7" name="buy_comic_orig_amount" id="buy_comic_orig_amount" value="<?php echo $ceo_options['buy_comic_orig_amount']; ?>" />
+						<input type="text" size="7" name="buy_comic_orig_amount" id="buy_comic_orig_amount" value="<?php echo esc_attr($ceo_options['buy_comic_orig_amount']); ?>" />
 					</td>
 					<td>
 						<?php _e('How much are you selling the Original for? (Default price, can set individual prices in each comic post)','comiceasel'); ?>

--- a/options/general.php
+++ b/options/general.php
@@ -131,7 +131,7 @@ wp_dropdown_categories($args);
 ?>					
 					</td>
 					<td>
-						<?php echo $ceo_options['chapter_on_home']; ?>
+						<?php echo esc_html($ceo_options['chapter_on_home']); ?>
 						<?php _e('Select which chapter or (all) to display on the home page if you have different stories/chapters.','comiceasel'); ?>
 					</td>
 				</tr>
@@ -161,7 +161,7 @@ wp_dropdown_categories($args);
 $thumbnail_sizes = get_intermediate_image_sizes();
 if (!in_array($ceo_options['thumbnail_size_for_rss'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_rss'] != 'none') && ($ceo_options['thumbnail_size_for_rss'] != 'full')) $ceo_options['thumbnail_size_for_rss'] = 'full';
 foreach ($thumbnail_sizes as $size) { ?>
-							<option class="level-0" value="<?php echo $size; ?>" <?php selected( $ceo_options['thumbnail_size_for_rss'], $size); ?>><?php echo ucfirst($size); ?></option>
+							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_rss'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
 							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_rss'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>
 						</select>
@@ -178,7 +178,7 @@ foreach ($thumbnail_sizes as $size) { ?>
 <?php 
 if (!in_array($ceo_options['thumbnail_size_for_direct_rss'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_direct_rss'] != 'none') && ($ceo_options['thumbnail_size_for_direct_rss'] != 'full')) $ceo_options['thumbnail_size_for_direct_rss'] = 'full';
 foreach ($thumbnail_sizes as $size) { ?>
-							<option class="level-0" value="<?php echo $size; ?>" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'], $size); ?>><?php echo ucfirst($size); ?></option>
+							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
 							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>
 						</select>
@@ -195,7 +195,7 @@ foreach ($thumbnail_sizes as $size) { ?>
 <?php 
 if (!in_array($ceo_options['thumbnail_size_for_archive'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_archive'] != 'none') && ($ceo_options['thumbnail_size_for_archive'] != 'full')) $ceo_options['thumbnail_size_for_archive'] = 'large';
 foreach ($thumbnail_sizes as $size) { ?>
-							<option class="level-0" value="<?php echo $size; ?>" <?php selected( $ceo_options['thumbnail_size_for_archive'], $size); ?>><?php echo ucfirst($size); ?></option>
+							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_archive'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
 							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_archive'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>							
 						</select>
@@ -212,7 +212,7 @@ foreach ($thumbnail_sizes as $size) { ?>
 <?php 
 if (!in_array($ceo_options['thumbnail_size_for_facebook'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_facebook'] != 'none') && ($ceo_options['thumbnail_size_for_facebook'] != 'full')) $ceo_options['thumbnail_size_for_facebook'] = 'large';
 foreach ($thumbnail_sizes as $size) { ?>
-							<option class="level-0" value="<?php echo $size; ?>" <?php selected( $ceo_options['thumbnail_size_for_facebook'], $size); ?>><?php echo ucfirst($size); ?></option>
+							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_facebook'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
 							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_facebook'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>							
 						</select>

--- a/options/navigation.php
+++ b/options/navigation.php
@@ -88,7 +88,7 @@ foreach ($dirs_to_search as $gnav_dir) {
 foreach ($gnav_directories as $gnav_dirs) {
 	if (is_dir($gnav_dirs)) {
 											$gnav_dir_name = basename($gnav_dirs); ?>
-											<option class="level-0" value="<?php echo $gnav_dir_name; ?>" <?php selected($current_gnav_directory, $gnav_dir_name); ?>><?php echo $gnav_dir_name; ?></option>
+											<option class="level-0" value="<?php echo esc_attr($gnav_dir_name); ?>" <?php selected($current_gnav_directory, $gnav_dir_name); ?>><?php echo esc_html($gnav_dir_name); ?></option>
 	<?php }
 }
 								?>

--- a/tests/ShortcodeInjectionTest.php
+++ b/tests/ShortcodeInjectionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * SQL injection via shortcode attributes — functions/shortcodes.php
+ *
+ * [comic-archive] and [cast-page] pass their attributes into hand-built SQL. Shortcode
+ * attributes are authored content, so on a site with more than one contributor these are
+ * untrusted input: anyone who can write a post can set them.
+ *
+ * The $wpdb spy records the SQL, so these assert on the query text with no database. That is
+ * the right tool here regardless — the queries use MySQL-only date functions, so a SQLite test
+ * database would not tell us the truth about them.
+ */
+class ShortcodeInjectionTest extends CE_TestCase {
+
+	/** @var CE_WPDB_Spy */
+	private $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/shortcodes.php' );
+		$this->wpdb = $this->useWpdbSpy();
+		$_GET['archive_year'] = '2020';
+	}
+
+	protected function tearDown(): void {
+		unset( $_GET['archive_year'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * ORDER BY cannot be a prepare() placeholder, so the direction has to be whitelisted.
+	 * Anything that is not recognisably DESC must come out as the literal ASC.
+	 */
+	#[DataProvider( 'orderProvider' )]
+	public function testOrderDirectionIsWhitelisted( $given, $expected ) {
+		ceo_archive_list_by_year( false, $given, 5 );
+		$sql = $this->wpdb->last();
+		$this->assertStringContainsString( 'ORDER BY post_date ' . $expected, $sql );
+	}
+
+	public static function orderProvider() {
+		return array(
+			'lowercase desc'   => array( 'desc', 'DESC' ),
+			'uppercase DESC'   => array( 'DESC', 'DESC' ),
+			'lowercase asc'    => array( 'asc', 'ASC' ),
+			'empty'            => array( '', 'ASC' ),
+			'sql appended'     => array( 'ASC; DROP TABLE wp_posts', 'ASC' ),
+			'comment injection'=> array( 'DESC--', 'ASC' ),
+			'union attempt'    => array( 'ASC UNION SELECT user_pass FROM wp_users', 'ASC' ),
+			'leading space'    => array( ' DESC', 'ASC' ),
+		);
+	}
+
+	#[DataProvider( 'injectionProvider' )]
+	public function testInjectedSqlNeverReachesTheYearQuery( $order, $chapter, $needle ) {
+		ceo_archive_list_by_year( false, $order, $chapter );
+		$this->assertFalse(
+			$this->wpdb->sawSql( $needle ),
+			'attacker-controlled text must not appear anywhere in the SQL'
+		);
+	}
+
+	#[DataProvider( 'injectionProvider' )]
+	public function testInjectedSqlNeverReachesTheAllYearsQuery( $order, $chapter, $needle ) {
+		ceo_archive_list_by_all_years( false, $order, $chapter );
+		$this->assertFalse( $this->wpdb->sawSql( $needle ) );
+	}
+
+	public static function injectionProvider() {
+		return array(
+			'union via chapter'   => array( 'ASC', '5 UNION SELECT user_pass FROM wp_users', 'user_pass' ),
+			'or-true via chapter' => array( 'ASC', '5 OR 1=1', 'OR 1=1' ),
+			'comment via chapter' => array( 'ASC', '5 -- ', '-- ' ),
+			'drop via order'      => array( 'ASC; DROP TABLE wp_posts', 0, 'DROP TABLE' ),
+			'sleep via order'     => array( 'ASC, SLEEP(5)', 0, 'SLEEP' ),
+		);
+	}
+
+	#[DataProvider( 'chapterCastProvider' )]
+	public function testChapterIsCastToIntegerInTheYearQuery( $given, $expected ) {
+		ceo_archive_list_by_year( false, 'ASC', $given );
+		$this->assertStringContainsString( 'term_id = ' . $expected, $this->wpdb->last() );
+	}
+
+	public static function chapterCastProvider() {
+		return array(
+			'plain integer'   => array( 5, '5' ),
+			'numeric string'  => array( '5', '5' ),
+			'injection'       => array( '5 OR 1=1', '5' ),
+			'float'           => array( 1.9, '1' ),
+		);
+	}
+
+	/**
+	 * [cast-page chapter=N] — the same attribute reaching a different query.
+	 */
+	public function testCastPageChapterIsParameterised() {
+		ceo_get_character_list( '5 UNION SELECT user_pass FROM wp_users' );
+		$sql = $this->wpdb->last();
+		$this->assertStringContainsString( 'terms1.term_id = 5', $sql );
+		$this->assertStringNotContainsString( 'user_pass', $sql );
+	}
+
+	public function testCastPageChapterAcceptsALegitimateId() {
+		ceo_get_character_list( 42 );
+		$this->assertStringContainsString( 'terms1.term_id = 42', $this->wpdb->last() );
+	}
+}

--- a/widgets/bf_adwidget.php
+++ b/widgets/bf_adwidget.php
@@ -29,9 +29,9 @@ class ceo_bf_adwidget extends WP_Widget {
 		if ($divID) {
 			echo $before_widget;
 			$title = empty($instance['title']) ? '' : apply_filters('widget_title', $instance['title']); 
-			if ( !empty( $title ) ) { echo $before_title . $title . $after_title; };
+			if ( !empty( $title ) ) { echo $before_title . esc_html( $title ) . $after_title; };
 			if ($center) echo '<center>';
-				if ($divID) echo '<div id="'.$divID.'"></div>';
+				if ($divID) echo '<div id="'.esc_attr($divID).'"></div>';
 			if ($center) echo '</center>';
 			echo $after_widget;
 		}

--- a/widgets/comic-calendar.php
+++ b/widgets/comic-calendar.php
@@ -268,9 +268,9 @@ class ceo_calendar_widget extends WP_Widget {
 				<?php if (!empty($thumbnail)) { ?>
 					<div class="wp-calendar-download">
 					<?php if (!empty($link)) { ?>
-						<a href="<?php echo esc_attr($link); ?>"><img src="<?php echo esc_attr($thumbnail); ?>" class="wp-calendar-thumb" alt="" /></a>
+						<a href="<?php echo esc_url($link); ?>"><img src="<?php echo esc_url($thumbnail); ?>" class="wp-calendar-thumb" alt="" /></a>
 					<?php } else { ?>
-						<img src="<?php echo esc_attr($thumbnail); ?>" class="wp-calendar-thumb" alt="" />
+						<img src="<?php echo esc_url($thumbnail); ?>" class="wp-calendar-thumb" alt="" />
 					<?php } ?>
 						<div class="wp-calendar-download-links">
 							<?php if (!empty($small) || !empty($medium) || !empty($large)) { ?>
@@ -282,7 +282,7 @@ class ceo_calendar_widget extends WP_Widget {
 								  	'large' => array(__('Download Large', 'comiceasel'), __('L', 'comiceasel'))
 								 	) as $field => $text) {
 								 		if (!empty(${$field})) {
-								 			?><a href="<?php echo esc_attr(${$field}); ?>" title="<?php echo esc_attr($text[0]); ?>"><?php echo esc_html($text[1]); ?></a><?php
+								 			?><a href="<?php echo esc_url(${$field}); ?>" title="<?php echo esc_attr($text[0]); ?>"><?php echo esc_html($text[1]); ?></a><?php
 								 		}
 								 	}
 							} ?>

--- a/widgets/navigation.php
+++ b/widgets/navigation.php
@@ -61,37 +61,37 @@ class ceo_comic_navigation_widget extends WP_Widget {
 		do_action('before-comic-navigation');
 		if ($instance['first']) {
 			if (!empty($first_comic) && ($first_comic !== $this_permalink)) { ?>
-				<a href="<?php echo $first_comic; ?>" class="navi navi-first" title="<?php echo $instance['first_title']; ?>"><?php echo $instance['first_title']; ?></a>
+				<a href="<?php echo esc_url($first_comic); ?>" class="navi navi-first" title="<?php echo esc_attr($instance['first_title']); ?>"><?php echo esc_html($instance['first_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-first navi-void"><?php echo $instance['first_title']; ?></span>
+				<span class="navi navi-first navi-void"><?php echo esc_html($instance['first_title']); ?></span>
 			<?php } 
 		}
 		if ($instance['first_in']) {
 			if (!empty($first_in_comic) && ($first_in_comic !== $this_permalink)) { ?>
-				<a href="<?php echo $first_in_comic; ?>" class="navi navi-first-in" title="<?php echo $instance['first_in_title']; ?>"><?php echo $instance['first_in_title']; ?></a>
+				<a href="<?php echo esc_url($first_in_comic); ?>" class="navi navi-first-in" title="<?php echo esc_attr($instance['first_in_title']); ?>"><?php echo esc_html($instance['first_in_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-first-in navi-void"><?php echo $instance['first_in_title']; ?></span>
+				<span class="navi navi-first-in navi-void"><?php echo esc_html($instance['first_in_title']); ?></span>
 			<?php } 
 		}
 		if ($instance['previous']) {
 			if (!empty($prev_comic)) { ?>
-				<a href="<?php echo $prev_comic; ?>" class="navi comic-nav-previous navi-prev" title="<?php echo $instance['previous_title']; ?>"><?php echo $instance['previous_title']; ?></a>
+				<a href="<?php echo esc_url($prev_comic); ?>" class="navi comic-nav-previous navi-prev" title="<?php echo esc_attr($instance['previous_title']); ?>"><?php echo esc_html($instance['previous_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-prev navi-void"><?php echo $instance['previous_title']; ?></span>
+				<span class="navi navi-prev navi-void"><?php echo esc_html($instance['previous_title']); ?></span>
 			<?php }
 		}
 		if ($instance['previous_in']) {
 			if (!empty($prev_in_comic)) { ?>
-				<a href="<?php echo $prev_in_comic; ?>" class="navi navi-prev-in" title="<?php echo $instance['previous_in_title']; ?>"><?php echo $instance['previous_in_title']; ?></a>
+				<a href="<?php echo esc_url($prev_in_comic); ?>" class="navi navi-prev-in" title="<?php echo esc_attr($instance['previous_in_title']); ?>"><?php echo esc_html($instance['previous_in_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-prev-in navi-void"><?php echo $instance['previous_in_title']; ?></span>
+				<span class="navi navi-prev-in navi-void"><?php echo esc_html($instance['previous_in_title']); ?></span>
 			<?php }
 		}
 		if ($instance['previous_chap']) {
 			if (!empty($previous_chap)) { ?>
-				<a href="<?php echo $previous_chap; ?>" class="navi navi-prev-chap" title="<?php echo $instance['previous_chap_title']; ?>"><?php echo $instance['previous_chap_title']; ?></a>
+				<a href="<?php echo esc_url($previous_chap); ?>" class="navi navi-prev-chap" title="<?php echo esc_attr($instance['previous_chap_title']); ?>"><?php echo esc_html($instance['previous_chap_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-prev-chap navi-void"><?php echo $instance['previous_chap_title']; ?></span>
+				<span class="navi navi-prev-chap navi-void"><?php echo esc_html($instance['previous_chap_title']); ?></span>
 			<?php } 
 		} 
 		?>
@@ -99,7 +99,7 @@ class ceo_comic_navigation_widget extends WP_Widget {
 		<td class="comic_navi_center">
 		<?php
 		if ($instance['archives'] && !empty($instance['archive_path'])) { ?>
-			<a href="<?php echo $instance['archive_path']; ?>" class="navi navi-archives navi-archive" title="<?php echo $instance['archives_title']; ?>"><?php echo $instance['archives_title']; ?></a>
+			<a href="<?php echo esc_url($instance['archive_path']); ?>" class="navi navi-archives navi-archive" title="<?php echo esc_attr($instance['archives_title']); ?>"><?php echo esc_html($instance['archives_title']); ?></a>
 		<?php } 
 		if ($instance['random']) {
 			$stay = '';	
@@ -108,7 +108,7 @@ class ceo_comic_navigation_widget extends WP_Widget {
 				if (!empty($chapter) && !is_wp_error($chapter)) $stay = '&stay='.reset($chapter)->term_id;
 			}
 			?>
-			<a href="<?php echo home_url(); ?>/?random&amp;nocache=1<?php echo $stay; ?>" class="navi navi-random" title="<?php echo $instance['random_title']; ?>"><?php echo $instance['random_title']; ?></a>
+			<a href="<?php echo esc_url(home_url()); ?>/?random&amp;nocache=1<?php echo esc_attr($stay); ?>" class="navi navi-random" title="<?php echo esc_attr($instance['random_title']); ?>"><?php echo esc_html($instance['random_title']); ?></a>
 		<?php }
 		if (ceo_pluginfo('enable_buy_comic') && isset($instance['buycomic']) && $instance['buycomic']) {
 			if (strpos(ceo_pluginfo('buy_comic_url'), '?') !== false) {
@@ -117,53 +117,53 @@ class ceo_comic_navigation_widget extends WP_Widget {
 				$bpsep = '?';
 			}
 		?>
-			<a href="<?php echo ceo_pluginfo('buy_comic_url').$bpsep.'id='.$post->ID; ?>" class="navi navi-buycomic" title="<?php echo $instance['buycomic_title']; ?>"><?php echo $instance['buycomic_title']; ?></a>
+			<a href="<?php echo esc_url(ceo_pluginfo('buy_comic_url').$bpsep.'id='.$post->ID); ?>" class="navi navi-buycomic" title="<?php echo esc_attr($instance['buycomic_title']); ?>"><?php echo esc_html($instance['buycomic_title']); ?></a>
 		<?php
 		}
 		do_action('inside-comic-navigation');
 		if ($instance['comments']) { ?>
-			<a href="<?php the_permalink(); ?>#comments" class="navi navi-comments" title="<?php echo $instance['comments_title']; ?>"><span class="navi-comments-count"><?php echo get_comments_number(); ?></span><?php echo $instance['comments_title']; ?></a>
+			<a href="<?php the_permalink(); ?>#comments" class="navi navi-comments" title="<?php echo esc_attr($instance['comments_title']); ?>"><span class="navi-comments-count"><?php echo get_comments_number(); ?></span><?php echo esc_html($instance['comments_title']); ?></a>
 		<?php } ?>
 		</td>
 		<td class="comic_navi_right">
 		<?php
 		if ($instance['next_chap']) {
 			if (!empty($next_chap)) { ?>
-				<a href="<?php echo $next_chap; ?>" class="navi navi-next-chap" title="<?php echo $instance['next_chap_title']; ?>"><?php echo $instance['next_chap_title']; ?></a>
+				<a href="<?php echo esc_url($next_chap); ?>" class="navi navi-next-chap" title="<?php echo esc_attr($instance['next_chap_title']); ?>"><?php echo esc_html($instance['next_chap_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-next-chap navi-void"><?php echo $instance['next_chap_title']; ?></span>
+				<span class="navi navi-next-chap navi-void"><?php echo esc_html($instance['next_chap_title']); ?></span>
 			<?php } 
 		}
 		if ($instance['next_in']) {
 			if (!empty($next_in_comic)) { ?>
-				<a href="<?php echo $next_in_comic; ?>" class="navi navi-next-in" title="<?php echo $instance['next_in_title']; ?>"><?php echo $instance['next_in_title']; ?></a>
+				<a href="<?php echo esc_url($next_in_comic); ?>" class="navi navi-next-in" title="<?php echo esc_attr($instance['next_in_title']); ?>"><?php echo esc_html($instance['next_in_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-next-in navi-void"><?php echo $instance['next_in_title']; ?></span>
+				<span class="navi navi-next-in navi-void"><?php echo esc_html($instance['next_in_title']); ?></span>
 			<?php }
 		}
 		if ($instance['next']) {
 			if (!empty($next_comic)) { ?>
-				<a href="<?php echo $next_comic; ?>" class="navi comic-nav-next navi-next" title="<?php echo $instance['next_title']; ?>"><?php echo $instance['next_title']; ?></a>
+				<a href="<?php echo esc_url($next_comic); ?>" class="navi comic-nav-next navi-next" title="<?php echo esc_attr($instance['next_title']); ?>"><?php echo esc_html($instance['next_title']); ?></a>
 			<?php } else { ?>
-				<span class="navi navi-next navi-void"><?php echo $instance['next_title']; ?></span>
+				<span class="navi navi-next navi-void"><?php echo esc_html($instance['next_title']); ?></span>
 			<?php }
 		}
 		if ($instance['last_in']) {
 			if (!empty($last_in_comic) && ($last_in_comic !== $this_permalink)) { ?>
-				<a href="<?php echo $last_in_comic; ?>" class="navi navi-last-in" title="<?php echo $instance['last_in_title']; ?>"><?php echo $instance['last_in_title']; ?></a>                  
+				<a href="<?php echo esc_url($last_in_comic); ?>" class="navi navi-last-in" title="<?php echo esc_attr($instance['last_in_title']); ?>"><?php echo esc_html($instance['last_in_title']); ?></a>                  
 			<?php } else { ?>
-				<span class="navi navi-last-in navi-void"><?php echo $instance['last_in_title']; ?></span>
+				<span class="navi navi-last-in navi-void"><?php echo esc_html($instance['last_in_title']); ?></span>
 			<?php }
 		}
 		if ($instance['last']) {
 			if (!empty($last_comic) && ($last_comic !== $this_permalink)) {
 				if (isset($instance['lastgohome']) && $instance['lastgohome']) { ?>
-					<a href="/" class="navi navi-last" title="<?php echo $instance['last_title']; ?>"><?php echo $instance['last_title']; ?></a>
+					<a href="/" class="navi navi-last" title="<?php echo esc_attr($instance['last_title']); ?>"><?php echo esc_html($instance['last_title']); ?></a>
 				<?php } else { ?>
-					<a href="<?php echo $last_comic; ?>" class="navi navi-last" title="<?php echo $instance['last_title']; ?>"><?php echo $instance['last_title']; ?></a>                  
+					<a href="<?php echo esc_url($last_comic); ?>" class="navi navi-last" title="<?php echo esc_attr($instance['last_title']); ?>"><?php echo esc_html($instance['last_title']); ?></a>                  
 				<?php } ?>
 			<?php } else { ?>
-				<span class="navi navi-last navi-void"><?php echo $instance['last_title']; ?></span>
+				<span class="navi navi-last navi-void"><?php echo esc_html($instance['last_title']); ?></span>
 			<?php }
 		} 
 		do_action('after-comic-navigation');
@@ -178,7 +178,7 @@ class ceo_comic_navigation_widget extends WP_Widget {
 			$thumbnail = wp_get_attachment_image_src( $post_image_id, 'full', false);
 			if (is_array($thumbnail) && !empty($thumbnail)) { 
 				$thumbnail = reset($thumbnail);
-				echo '<span class="comic-navi-href-info">'.__('Image URL (for hotlinking/embedding):','comiceasel').'&nbsp;'.$thumbnail.'</span>';
+				echo '<span class="comic-navi-href-info">'.__('Image URL (for hotlinking/embedding):','comiceasel').'&nbsp;'.esc_url($thumbnail).'</span>';
 			}
 			?>
 			</td>
@@ -293,43 +293,43 @@ class ceo_comic_navigation_widget extends WP_Widget {
 					));
 		?>
 		<input id="<?php echo $this->get_field_id('first'); ?>" name="<?php echo $this->get_field_name('first'); ?>" type="checkbox" value="1" <?php checked(true, $instance['first']); ?> /> <label for="<?php echo $this->get_field_id('first'); ?>"><strong><?php _e('First','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('first_title'); ?>" name="<?php echo $this->get_field_name('first_title'); ?>" type="text" value="<?php echo $instance['first_title']; ?>" /><br /> 
+		<input id="<?php echo $this->get_field_id('first_title'); ?>" name="<?php echo $this->get_field_name('first_title'); ?>" type="text" value="<?php echo esc_attr($instance['first_title']); ?>" /><br /> 
 		<br />
 
 		<input id="<?php echo $this->get_field_id('last'); ?>" name="<?php echo $this->get_field_name('last'); ?>" type="checkbox" value="1" <?php checked(true, $instance['last']); ?> /> <label for="<?php echo $this->get_field_id('last'); ?>"><strong><?php _e('Last','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('last_title'); ?>" name="<?php echo $this->get_field_name('last_title'); ?>" type="text" value="<?php echo $instance['last_title']; ?>" /><br />
+		<input id="<?php echo $this->get_field_id('last_title'); ?>" name="<?php echo $this->get_field_name('last_title'); ?>" type="text" value="<?php echo esc_attr($instance['last_title']); ?>" /><br />
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('previous'); ?>" name="<?php echo $this->get_field_name('previous'); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous']); ?> /> <label for="<?php echo $this->get_field_id('previous'); ?>"><strong><?php _e('Previous','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('previous_title'); ?>" name="<?php echo $this->get_field_name('previous_title'); ?>" type="text" value="<?php echo $instance['previous_title']; ?>" /><br />
+		<input id="<?php echo $this->get_field_id('previous_title'); ?>" name="<?php echo $this->get_field_name('previous_title'); ?>" type="text" value="<?php echo esc_attr($instance['previous_title']); ?>" /><br />
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('next'); ?>" name="<?php echo $this->get_field_name('next'); ?>" type="checkbox" value="1" <?php checked(true, $instance['next']); ?> /> <label for="<?php echo $this->get_field_id('next'); ?>"><strong><?php _e('Next','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('next_title'); ?>" name="<?php echo $this->get_field_name('next_title'); ?>" type="text" value="<?php echo $instance['next_title']; ?>" /><br />
+		<input id="<?php echo $this->get_field_id('next_title'); ?>" name="<?php echo $this->get_field_name('next_title'); ?>" type="text" value="<?php echo esc_attr($instance['next_title']); ?>" /><br />
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('first_in'); ?>" name="<?php echo $this->get_field_name('first_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['first_in']); ?> /> <label for="<?php echo $this->get_field_id('first_in'); ?>"><strong><?php _e('First in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('first_in_title'); ?>" name="<?php echo $this->get_field_name('first_in_title'); ?>" type="text" value="<?php echo $instance['first_in_title']; ?>" /><br />   
+		<input id="<?php echo $this->get_field_id('first_in_title'); ?>" name="<?php echo $this->get_field_name('first_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['first_in_title']); ?>" /><br />   
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('last_in'); ?>" name="<?php echo $this->get_field_name('last_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['last_in']); ?> /> <label for="<?php echo $this->get_field_id('last_in'); ?>"><strong><?php _e('Last in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('last_in_title'); ?>" name="<?php echo $this->get_field_name('last_in_title'); ?>" type="text" value="<?php echo $instance['last_in_title']; ?>" /><br />
+		<input id="<?php echo $this->get_field_id('last_in_title'); ?>" name="<?php echo $this->get_field_name('last_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['last_in_title']); ?>" /><br />
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('previous_in'); ?>" name="<?php echo $this->get_field_name('previous_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous_in']); ?> /> <label for="<?php echo $this->get_field_id('previous_in'); ?>"><strong><?php _e('Previous in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('previous_in_title'); ?>" name="<?php echo $this->get_field_name('previous_in_title'); ?>" type="text" value="<?php echo $instance['previous_in_title']; ?>" /><br />   
+		<input id="<?php echo $this->get_field_id('previous_in_title'); ?>" name="<?php echo $this->get_field_name('previous_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['previous_in_title']); ?>" /><br />   
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('next_in'); ?>" name="<?php echo $this->get_field_name('next_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['next_in']); ?> /> <label for="<?php echo $this->get_field_id('next_in'); ?>"><strong><?php _e('Next in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('next_in_title'); ?>" name="<?php echo $this->get_field_name('next_in_title'); ?>" type="text" value="<?php echo $instance['next_in_title']; ?>" /><br />
+		<input id="<?php echo $this->get_field_id('next_in_title'); ?>" name="<?php echo $this->get_field_name('next_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['next_in_title']); ?>" /><br />
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('previous_chap'); ?>" name="<?php echo $this->get_field_name('previous_chap'); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous_chap']); ?> /> <label for="<?php echo $this->get_field_id('previous_chap'); ?>"><strong><?php _e('Previous Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('previous_chap_title'); ?>" name="<?php echo $this->get_field_name('previous_chap_title'); ?>" type="text" value="<?php echo $instance['previous_chap_title']; ?>" /><br />   
+		<input id="<?php echo $this->get_field_id('previous_chap_title'); ?>" name="<?php echo $this->get_field_name('previous_chap_title'); ?>" type="text" value="<?php echo esc_attr($instance['previous_chap_title']); ?>" /><br />   
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('next_chap'); ?>" name="<?php echo $this->get_field_name('next_chap'); ?>" type="checkbox" value="1" <?php checked(true, $instance['next_chap']); ?> /> <label for="<?php echo $this->get_field_id('next_chap'); ?>"><strong><?php _e('Next Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('next_chap_title'); ?>" name="<?php echo $this->get_field_name('next_chap_title'); ?>" type="text" value="<?php echo $instance['next_chap_title']; ?>" /><br />
+		<input id="<?php echo $this->get_field_id('next_chap_title'); ?>" name="<?php echo $this->get_field_name('next_chap_title'); ?>" type="text" value="<?php echo esc_attr($instance['next_chap_title']); ?>" /><br />
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('comictitle'); ?>" name="<?php echo $this->get_field_name('comictitle'); ?>" type="checkbox" value="1" <?php checked(true, $instance['comictitle']); ?> /> <label for="<?php echo $this->get_field_id('comictitle'); ?>"><strong><?php _e('Comic Title','comiceasel'); ?></strong></label>
@@ -339,20 +339,20 @@ class ceo_comic_navigation_widget extends WP_Widget {
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('archives'); ?>" name="<?php echo $this->get_field_name('archives'); ?>" type="checkbox" value="1" <?php checked(true, $instance['archives']); ?> /> <label for="<?php echo $this->get_field_id('archives'); ?>"><strong><?php _e('Archives','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('archives_title'); ?>" name="<?php echo $this->get_field_name('archives_title'); ?>" type="text" value="<?php echo $instance['archives_title']; ?>" /><br />   
-		Archive URL: <input class="widefat" id="<?php echo $this->get_field_id('archive_path'); ?>" name="<?php echo $this->get_field_name('archive_path'); ?>" type="text" value="<?php echo $instance['archive_path']; ?>" /><br />
+		<input id="<?php echo $this->get_field_id('archives_title'); ?>" name="<?php echo $this->get_field_name('archives_title'); ?>" type="text" value="<?php echo esc_attr($instance['archives_title']); ?>" /><br />   
+		Archive URL: <input class="widefat" id="<?php echo $this->get_field_id('archive_path'); ?>" name="<?php echo $this->get_field_name('archive_path'); ?>" type="text" value="<?php echo esc_attr($instance['archive_path']); ?>" /><br />
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('comments'); ?>" name="<?php echo $this->get_field_name('comments'); ?>" type="checkbox" value="1" <?php checked(true, $instance['comments']); ?> /> <label for="<?php echo $this->get_field_id('comments'); ?>"><strong><?php _e('Comments','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('comments_title'); ?>" name="<?php echo $this->get_field_name('comments_title'); ?>" type="text" value="<?php echo $instance['comments_title']; ?>" /><br />   
+		<input id="<?php echo $this->get_field_id('comments_title'); ?>" name="<?php echo $this->get_field_name('comments_title'); ?>" type="text" value="<?php echo esc_attr($instance['comments_title']); ?>" /><br />   
 		<br />
 		
 		<input id="<?php echo $this->get_field_id('random'); ?>" name="<?php echo $this->get_field_name('random'); ?>" type="checkbox" value="1" <?php checked(true, $instance['random']); ?> /> <label for="<?php echo $this->get_field_id('random'); ?>"><strong><?php _e('Random','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('random_title'); ?>" name="<?php echo $this->get_field_name('random_title'); ?>" type="text" value="<?php echo $instance['random_title']; ?>" /><br />   
+		<input id="<?php echo $this->get_field_id('random_title'); ?>" name="<?php echo $this->get_field_name('random_title'); ?>" type="text" value="<?php echo esc_attr($instance['random_title']); ?>" /><br />   
 		<br />
 <?php if (ceo_pluginfo('enable_buy_comic')) { ?>
 		<input id="<?php echo $this->get_field_id('buycomic'); ?>" name="<?php echo $this->get_field_name('buycomic'); ?>" type="checkbox" value="1" <?php checked(true, $instance['buycomic']); ?> /> <label for="<?php echo $this->get_field_id('buycomic'); ?>"><strong><?php _e('Buy!','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('buycomic_title'); ?>" name="<?php echo $this->get_field_name('buycomic_title'); ?>" type="text" value="<?php echo $instance['buycomic_title']; ?>" /><br />   
+		<input id="<?php echo $this->get_field_id('buycomic_title'); ?>" name="<?php echo $this->get_field_name('buycomic_title'); ?>" type="text" value="<?php echo esc_attr($instance['buycomic_title']); ?>" /><br />   
 		<br />
 <?php } ?>		
 		<input id="<?php echo $this->get_field_id('imageurl'); ?>" name="<?php echo $this->get_field_name('imageurl'); ?>" type="checkbox" value="1" <?php checked(true, $instance['imageurl']); ?> /> <label for="<?php echo $this->get_field_id('imageurl'); ?>"><strong><?php _e('ImageURL','comiceasel'); ?></strong></label>


### PR DESCRIPTION
Second in the series, following #38 (now merged, so the diff below is just this PR's own 21 commits).

Everything here is output escaping, input sanitising, and two access checks. I've deliberately kept to changes that shouldn't be noticeable on a working site — the fixes that *could* affect existing installs are held back for the next PR, so this one can be reviewed and merged without much risk.

## What's in it

- **Two queries** built their SQL by concatenating shortcode attributes. Now cast/whitelisted and passed through `$wpdb->prepare()`.
- **Output escaping** across the settings screens, the Debug page, the buy-comic forms, the widget output and admin forms, the archive listings, the comic navigation, the flash embed, the taxonomy columns in the Comics list, and the `wp_head` meta tag. Storage is untouched throughout, so nothing gets double-encoded and existing values keep working.
- **Two access checks**: the settings-reset handler now verifies the nonce its own form already emits and requires `edit_theme_options`; `[buycomic]` now requires the ID to be a published, non-password-protected comic instead of rendering whatever `get_post()` returned.
- One PHP 8 warning cleanup in the settings pages, and a test asserting the shortcode attributes can't reach the SQL.

## Testing

CI covers `php -l` on PHP 7.4–8.4, PHPUnit on 8.2–8.4, and PHPCS on changed lines.

Beyond that I ran this on a real WordPress (7.0 on SQLite, PHP 8.5, `WP_DEBUG` on, classic test theme), seeded so that **every field this PR escapes contained an attribute-breaking payload** — the config options, three taxonomy term names, a comic title, and the `link-to` / `flash_file` / `flash_width` / status post meta.

Then I ran the same fixtures against `master` and against this branch on the same running install, counting raw versus escaped occurrences:

| Page | master | this branch |
|---|---|---|
| Comics → Debug | 3 raw | 0 raw (3 escaped) |
| Config → Buy Comic | 2 raw | 0 raw (2 escaped) |
| `/shop/?id=5` (buy forms) | 3 raw | 0 raw (2 escaped) |
| single comic | 1 raw | 0 |
| `/shop/?id=6` (draft) | rendered its title | "Invalid Comic ID." |
| `/shop/?id=7` (password-protected) | rendered its title | "Invalid Comic ID." |

Checked in a browser rather than by grepping, since escaped text still contains the payload's characters: on this branch the buy page has **no elements carrying an inline event handler, no injected `<img>`, and no `javascript:` URLs**, and nothing fires even after dispatching `mouseover` and `error` at every element on the page. The hostile `buy_comic_url` ends up contained inside the PayPal form's `return` field rather than becoming markup. On the archive page the listing anchor carries exactly `href`, `rel` and `title` and no injected attributes.

The chapter-ordered archive listing needs a column that activation adds with MySQL-only DDL, so it does not render on SQLite. Verified separately on MySQL 9.7 with a comic titled `Boom" onmouseover="window.__PWN=1` — a title with no tags in it, so nothing is stripped on save:

- on `master` the listing anchor comes out with **four** attributes — `href`, `rel`, `title`, `onmouseover` — and the handler runs when a visitor hovers the row
- on this branch the same anchor has **three**, the title sits inside the `title` attribute, and nothing fires

All plugin admin screens load without a fatal — Config (both tabs), Monetize, Debug, Import, the Comics list table, `widgets.php`, and the chapters/characters screens. Across nine pages the debug log shows 6 plugin-origin lines, **identical on `master`** — a pre-existing `get_terms()` deprecation, not something introduced here.

