### PR TITLE
PayPal notification validation and comic HTML escaping (behaviour changes)

### DIFF
--- a/functions/admin-meta.php
+++ b/functions/admin-meta.php
@@ -1,5 +1,26 @@
 <?php
 
+/*
+ * Normalize a stored meta value before it is re-displayed in the post editor.
+ *
+ * These meta values exist in the database in two different shapes:
+ *   1. written through this plugin's own meta boxes - ceo_handle_edit_save_comic()
+ *      runs the submitted value through esc_textarea(), so <b> is stored as &lt;b&gt;
+ *   2. written through WordPress' built-in Custom Fields panel - the comic post type
+ *      supports 'custom-fields' and none of these keys are protected, so whatever was
+ *      typed is stored verbatim and <b> is stored as <b>
+ *
+ * Decoding first collapses both shapes back to the same plain text, which is what makes
+ * a single escape at the output sink correct for both: the already-encoded value is not
+ * double-encoded (&lt;b&gt; -> <b> -> &lt;b&gt;, byte-identical to what the raw echo used
+ * to emit), and the raw value can no longer break out of the surrounding markup
+ * (<script> -> <script> -> &lt;script&gt;). Callers must still apply the escaper that
+ * matches their context: esc_textarea() inside <textarea>, esc_attr() inside an attribute.
+ */
+function ceo_meta_for_editor($value) {
+	return html_entity_decode((string)$value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
+}
+
 add_action('admin_init', 'ceo_admin_init');
 
 function ceo_admin_init() {
@@ -253,10 +274,10 @@ function ceo_edit_toggles_in_post($post) {
 		<th scope="row"><label for="comic-gallery-columns"><?php _e('If not full sized, how many gallery rows to use?','comiceasel'); ?></label></th>
 		<td style="width: 30%">
 			<?php
-				$column_count = esc_attr( get_post_meta( $post->ID, 'comic-gallery-columns', true ));
+				$column_count = get_post_meta( $post->ID, 'comic-gallery-columns', true );
 				if (empty($column_count) || ($column_count > 10) || ($column_count < 1)) $column_count = 5;
 			?>
-			<input id="comic-gallery-columns" name="comic-gallery-columns" style="width: 40px;" type="text" value="<?php echo $column_count; ?>"  />
+			<input id="comic-gallery-columns" name="comic-gallery-columns" style="width: 40px;" type="text" value="<?php echo esc_attr(ceo_meta_for_editor($column_count)); ?>"  />
 		</td>
 	</tr>
 	<tr>
@@ -294,8 +315,8 @@ function ceo_media_embed_box($post) {
 You can add the url from:<br />
 blip.tv, DailyMotion, FunnyOrDie.com, Hulu, Instagram, Qik, Photobucket, Rdio, Revision3, Scribd, SlideShare, Smugmug, SoundCloud, Spotify, Youtube, Twitter, Vimeo, WordPress.tv<br />
 <em>You still need to add a featured image to be used as the thumbnail.</em><br />
-	<input id="media_url" name="media_url" type="input" style="width: 80%" value="<?php echo $media_url; ?>" /><br />
-	Width to use (default is global $content_width): <input id="media_width" name="media_width" type="input" style="width: 100px;" value="<?php echo $media_width; ?>" /> 
+	<input id="media_url" name="media_url" type="input" style="width: 80%" value="<?php echo esc_attr(ceo_meta_for_editor($media_url)); ?>" /><br />
+	Width to use (default is global $content_width): <input id="media_width" name="media_width" type="input" style="width: 100px;" value="<?php echo esc_attr(ceo_meta_for_editor($media_width)); ?>" />
 <?php
 }
 
@@ -304,7 +325,7 @@ function ceo_edit_linkto_in_post($post) {
 	_e('Add url here or leave empty to use next comic or default none', 'comiceasel');
 	?>
 	<br />
-	<input id="link-to" name="link-to" type="input" style="width: 80%" value="<?php echo $linkto_url; ?>" /><br />
+	<input id="link-to" name="link-to" type="input" style="width: 80%" value="<?php echo esc_attr(ceo_meta_for_editor($linkto_url)); ?>" /><br />
 	<?php
 }
 
@@ -314,21 +335,21 @@ function ceo_edit_refer_only_in_post($post) {
 	_e('Add url here of referring website to make it only visible when coming from that url.', 'comiceasel');
 	?>
 	<br />
-	<input id="refer-only" name="refer-only" type="input" style="width: 80%" value="<?php echo $refer_only; ?>" /><br />
+	<input id="refer-only" name="refer-only" type="input" style="width: 80%" value="<?php echo esc_attr(ceo_meta_for_editor($refer_only)); ?>" /><br />
 	<br />
 	<?php _e("Message to display to users who don't visit from the referring site.",'comiceasel'); ?><br />
-	<input id="refer-only-msg" name="refer-only-msg" type="input" style="width: 80%" value="<?php echo $refer_only_msg; ?>" /><br />
+	<input id="refer-only-msg" name="refer-only-msg" type="input" style="width: 80%" value="<?php echo esc_attr(ceo_meta_for_editor($refer_only_msg)); ?>" /><br />
 	<?php
 }
 
 function ceo_edit_hovertext_in_post($post) { 
 	wp_nonce_field( basename( __FILE__ ), 'comic_nonce' );
-	$hovertext = esc_attr( get_post_meta( $post->ID, 'comic-hovertext', true ) );
-	if (empty($hovertext)) $hovertext = esc_attr( get_post_meta($post->ID, 'hovertext', true));
+	$hovertext = get_post_meta( $post->ID, 'comic-hovertext', true );
+	if (empty($hovertext)) $hovertext = get_post_meta($post->ID, 'hovertext', true);
 	if (!$hovertext) $hovertext = '';
 ?>
 	<?php _e('The text placed here will appear when you mouse over the comic.','comiceasel'); ?><br />
-	<textarea name="comic-hovertext" id="comic-hovertext" class="admin-comic-hovertext" style="width:100%"><?php echo $hovertext; ?></textarea>
+	<textarea name="comic-hovertext" id="comic-hovertext" class="admin-comic-hovertext" style="width:100%"><?php echo esc_textarea(ceo_meta_for_editor($hovertext)); ?></textarea>
 <?php
 }
 
@@ -336,7 +357,7 @@ function ceo_edit_transcript_in_post($post) {
 	wp_nonce_field( basename( __FILE__ ), 'comic_nonce' );
 ?>
 	<?php _e('The text placed here will appear as the transcript.','comiceasel'); ?><br />
-	<textarea name="transcript" id="transcript" class="admin-transcript" style="width:100%; height: 100px;"><?php echo get_post_meta($post->ID, 'transcript', true); ?></textarea>
+	<textarea name="transcript" id="transcript" class="admin-transcript" style="width:100%; height: 100px;"><?php echo esc_textarea(ceo_meta_for_editor(get_post_meta($post->ID, 'transcript', true))); ?></textarea>
 <?php
 }
 
@@ -344,7 +365,7 @@ function ceo_edit_html_above_comic($post) {
 	wp_nonce_field( basename( __FILE__ ), 'comic_nonce' );
 ?>
 	<?php _e('The html placed here will appear above the comic.','comiceasel'); ?><br />
-	<textarea name="comic-html-above" id="comic-html-above" class="admin-comic-html-above" style="width:100%"><?php echo get_post_meta( $post->ID, 'comic-html-above', true ); ?></textarea>
+	<textarea name="comic-html-above" id="comic-html-above" class="admin-comic-html-above" style="width:100%"><?php echo esc_textarea(ceo_meta_for_editor(get_post_meta( $post->ID, 'comic-html-above', true ))); ?></textarea>
 <?php
 }
 
@@ -352,7 +373,7 @@ function ceo_edit_html_below_comic($post) {
 	wp_nonce_field( basename( __FILE__ ), 'comic_nonce' );
 ?>
 	<?php _e('The html placed here will appear below the comic.','comiceasel'); ?><br />
-	<textarea name="comic-html-below" id="comic-html-below" class="admin-comic-html-below" style="width:100%"><?php echo get_post_meta( $post->ID, 'comic-html-below', true ); ?></textarea>
+	<textarea name="comic-html-below" id="comic-html-below" class="admin-comic-html-below" style="width:100%"><?php echo esc_textarea(ceo_meta_for_editor(get_post_meta( $post->ID, 'comic-html-below', true ))); ?></textarea>
 <?php
 }
 
@@ -374,7 +395,7 @@ function ceo_edit_buycomic_in_post($post) {
 		<tr>
 		<?php if (ceo_pluginfo('buy_comic_sell_print')) { ?>
 			<td align="left" valign="top" width="50%">
-				<?php _e('Print Cost','comiceasel'); ?> <input name="buy_print_amount" id="buy_print_amount" type="text" size="5" value="<?php echo $currentbuyprintamount ?>" />  <br />
+				<?php _e('Print Cost','comiceasel'); ?> <input name="buy_print_amount" id="buy_print_amount" type="text" size="5" value="<?php echo esc_attr(ceo_meta_for_editor($currentbuyprintamount)) ?>" />  <br />
 				<input name="buyprint-status" id="buyprint-available" type="radio" value="<?php _e('Available','comiceasel'); ?>" <?php if (($currentbuyprintoption == __('Available','comiceasel')) || empty($currentbuyprintoption)) { echo " checked"; } ?> /> <label for="buyprint-available"><?php _e('Available','comiceasel'); ?></label><br />
 				<input name="buyprint-status" id="buyprint-sold" type="radio" value="<?php _e('Sold','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Sold','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-sold">Sold</label><br />
 				<input name="buyprint-status" id="buyprint-outofstock" type="radio" value="<?php _e('Out of Stock','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Out of Stock','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-outofstock"><?php _e('Out of Stock','comiceasel'); ?></label><br />
@@ -383,7 +404,7 @@ function ceo_edit_buycomic_in_post($post) {
 		<?php }
 			if (ceo_pluginfo('buy_comic_sell_original')) { ?>
 			<td align="left" valign="top">
-				<?php _e('Original Cost','comiceasel'); ?> <input name="buy_print_orig_amount" id="buy_print_orig_amount" size="5" type="text" value="<?php echo $currentbuyorigamount; ?>" /><br />
+				<?php _e('Original Cost','comiceasel'); ?> <input name="buy_print_orig_amount" id="buy_print_orig_amount" size="5" type="text" value="<?php echo esc_attr(ceo_meta_for_editor($currentbuyorigamount)); ?>" /><br />
 				<input name="buyorig-status" id="buyorig-available" type="radio" value="<?php _e('Available','comiceasel'); ?>" <?php if (($currentbuyorigoption == __('Available','comiceasel')) || empty($currentbuyorigoption)) { echo " checked"; } ?> /> <label for="buyorig-available"><?php _e('Available','comiceasel'); ?></label><br />
 				<input name="buyorig-status" id="buyorig-sold" type="radio" value="<?php _e('Sold','comiceasel'); ?>" <?php if ($currentbuyorigoption == __('Sold','comiceasel')) { echo " checked"; } ?> /> <label for="buyorig-sold"><?php _e('Sold','comiceasel'); ?></label><br />
 				<input name="buyorig-status" id="buyorig-notavail" type="radio" value="<?php _e('Not Available','comiceasel'); ?>" <?php if ($currentbuyorigoption == __('Not Available','comiceasel')) { echo " checked"; } ?> /> <label for="buyorig-notavail"><?php _e('Not Available','comiceasel'); ?></label><br />
@@ -397,13 +418,13 @@ function ceo_edit_buycomic_in_post($post) {
 function ceo_flash_upload_box($post) { ?>
 <label for="upload_flash">
     <?php _e('Enter a URL or upload a flash comic.','comiceasel'); ?><br />
-    <input id="flash_file" class="flash_file" type="text" name="flash_file" value="<?php echo get_post_meta( $post->ID, 'flash_file', true ); ?>" />
+    <input id="flash_file" class="flash_file" type="text" name="flash_file" value="<?php echo esc_attr(ceo_meta_for_editor(get_post_meta( $post->ID, 'flash_file', true ))); ?>" />
     <input name="upload_flash_button" class="upload_flash_button" type="button" value="<?php _e('Upload Flash','comiceasel'); ?>" /><br />
 </label>
 <br />
 <?php _e('Set the dimensions of the flash .swf comic.','comiceasel'); ?><br />
-<label for="flash_height"><?php _e('Height:','comiceasel'); ?> <input id="flash_height" name="flash_height" type="text" value="<?php echo get_post_meta( $post->ID, 'flash_height', true ); ?>" /></label>
-<label for="flash_width"><?php _e('Width:','comiceasel'); ?> <input id="flash_width" name="flash_width" type="text" value="<?php echo get_post_meta( $post->ID, 'flash_width', true ); ?>" /></label><br />
+<label for="flash_height"><?php _e('Height:','comiceasel'); ?> <input id="flash_height" name="flash_height" type="text" value="<?php echo esc_attr(ceo_meta_for_editor(get_post_meta( $post->ID, 'flash_height', true ))); ?>" /></label>
+<label for="flash_width"><?php _e('Width:','comiceasel'); ?> <input id="flash_width" name="flash_width" type="text" value="<?php echo esc_attr(ceo_meta_for_editor(get_post_meta( $post->ID, 'flash_width', true ))); ?>" /></label><br />
 <br />
 <em><?php _e('You still need to have a featured image set, it will be used as a thumbnail.','comiceasel'); ?></em>
 <?php }

--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -227,9 +227,18 @@ function ceo_the_hovertext($override_post = null) {
  */
 function ceo_comic_html_for_output($value, $post_to_use = null) {
 	$html = html_entity_decode((string)$value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
-	$author = (!is_null($post_to_use) && !empty($post_to_use->post_author)) ? (int)$post_to_use->post_author : 0;
-	if ($author && user_can($author, 'unfiltered_html')) return $html;
-	return wp_kses_post($html);
+	if (is_null($post_to_use) || empty($post_to_use->post_author)) return wp_kses_post($html);
+
+	$author = (int)$post_to_use->post_author;
+	if (!user_can($author, 'unfiltered_html')) return wp_kses_post($html);
+
+	// The author being trusted is not enough on its own: someone else may have
+	// edited the post since. On multisite an Editor lacks unfiltered_html but can
+	// still edit an administrator's comic, so check whoever touched it last too.
+	$last_editor = (int)get_post_meta($post_to_use->ID, '_edit_last', true);
+	if ($last_editor && $last_editor !== $author && !user_can($last_editor, 'unfiltered_html')) return wp_kses_post($html);
+
+	return $html;
 }
 
 function ceo_the_above_html($override_post = null) {

--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -162,11 +162,7 @@ function ceo_display_comic($size = 'full') {
 		$ref_only_msg = '';
 		$refer_only_msg = get_post_meta( $post->ID, 'refer-only-msg', 'true') ? get_post_meta( $post->ID, 'refer-only-msg', 'true') : __('Read post message below to find out how to view this.', 'comiceasel');
 		if (ceo_get_referer() !== $refer_only) {
-				// Same two storage shapes as the other comic meta: encoded when written
-				// through the meta box, raw when written through Custom Fields. Decode to
-				// normalise, then escape once with a double-encoding escaper so legacy
-				// values render exactly as before.
-				$refer_only_msg = htmlspecialchars(html_entity_decode((string)$refer_only_msg, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401), ENT_QUOTES, get_option('blog_charset'));
+				$refer_only_msg = ceo_escape_stored_text($refer_only_msg);
 				return apply_filters('ceo_refer_only_msg', $refer_only_msg);
 		}
 	}

--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -162,6 +162,11 @@ function ceo_display_comic($size = 'full') {
 		$ref_only_msg = '';
 		$refer_only_msg = get_post_meta( $post->ID, 'refer-only-msg', 'true') ? get_post_meta( $post->ID, 'refer-only-msg', 'true') : __('Read post message below to find out how to view this.', 'comiceasel');
 		if (ceo_get_referer() !== $refer_only) {
+				// Same two storage shapes as the other comic meta: encoded when written
+				// through the meta box, raw when written through Custom Fields. Decode to
+				// normalise, then escape once with a double-encoding escaper so legacy
+				// values render exactly as before.
+				$refer_only_msg = htmlspecialchars(html_entity_decode((string)$refer_only_msg, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401), ENT_QUOTES, get_option('blog_charset'));
 				return apply_filters('ceo_refer_only_msg', $refer_only_msg);
 		}
 	}

--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -166,7 +166,7 @@ function ceo_display_comic($size = 'full') {
 		}
 	}
 	$output = '';
-	if (ceo_the_above_html()) $output .= html_entity_decode(ceo_the_above_html(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)."\r\n";
+	if (ceo_the_above_html()) $output .= ceo_comic_html_for_output(ceo_the_above_html(), $post)."\r\n";
 
 	if ($flash_file = get_post_meta($post->ID, "flash_file", true)) {
 		$output .= ceo_display_flash_comic($post, $flash_file);
@@ -187,7 +187,7 @@ function ceo_display_comic($size = 'full') {
 			$output .= ceo_display_featured_image_comic($size);
 		}
 	}	
-	if (ceo_the_below_html()) $output .= html_entity_decode(ceo_the_below_html(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)."\r\n";
+	if (ceo_the_below_html()) $output .= ceo_comic_html_for_output(ceo_the_below_html(), $post)."\r\n";
 	if ($output) { 
 		return apply_filters('ceo_comics_display_comic', $output);
 	} else
@@ -208,6 +208,28 @@ function ceo_the_hovertext($override_post = null) {
 	if (empty($hovertext)) $hovertext = esc_attr( get_post_meta($post_to_use->ID, 'hovertext', true) ); // check if using old hovertext
 //	return (empty($hovertext)) ? get_the_title($post_to_use->ID) : $hovertext;
 	return (empty($hovertext)) ? '' : $hovertext;
+}
+
+/**
+ * Prepare a comic-html-above / comic-html-below value for output.
+ *
+ * These two fields are meant to hold markup, so the value is not escaped. It
+ * cannot be trusted blindly either: the meta keys are unprotected on a post
+ * type that declares custom-fields support, so anyone who can edit a comic can
+ * write to them through WordPress's own Custom Fields panel, bypassing the
+ * plugin's meta box entirely.
+ *
+ * The stored value therefore arrives in two shapes -- entity-encoded when it
+ * came through the meta box (which escapes on save), raw when it came through
+ * Custom Fields -- so decode first to normalise, then apply WordPress's own
+ * trust rule: content from an author who holds unfiltered_html renders as
+ * written, anything else is filtered exactly like post content would be.
+ */
+function ceo_comic_html_for_output($value, $post_to_use = null) {
+	$html = html_entity_decode((string)$value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
+	$author = (!is_null($post_to_use) && !empty($post_to_use->post_author)) ? (int)$post_to_use->post_author : 0;
+	if ($author && user_can($author, 'unfiltered_html')) return $html;
+	return wp_kses_post($html);
 }
 
 function ceo_the_above_html($override_post = null) {

--- a/functions/library.php
+++ b/functions/library.php
@@ -127,6 +127,33 @@ function ceo_get_referer() {
 	return $ref;
 }
 
+/**
+ * Escape a stored comic meta value for output as HTML text.
+ *
+ * These meta values exist in the database in two shapes: entity-encoded when written through
+ * the Comic Easel meta boxes, which escape on save, and raw when written through WordPress's
+ * own Custom Fields panel, which does not. Decoding first normalises both, so the escape
+ * below applies exactly once.
+ *
+ * htmlspecialchars() rather than esc_html(), and deliberately so: esc_html() passes
+ * $double_encode = false, which means it declines to re-encode text that already looks like
+ * an entity. A value an author typed as the literal characters "&lt;b&gt;" is stored as
+ * "&amp;lt;b&amp;gt;", and esc_html() would hand back "&lt;b&gt;" -- one level short. Repeat
+ * that on each save and the author's literal text decays into a live tag.
+ *
+ * ENT_SUBSTITUTE matters as much: from PHP 8.1 the default flag set is
+ * ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, and passing ENT_QUOTES alone REPLACES that
+ * default rather than adding to it. Without ENT_SUBSTITUTE a single invalid UTF-8 byte makes
+ * htmlspecialchars() return an empty string, silently blanking the whole value. The charset
+ * fallback is for the same reason -- an empty or unrecognised blog_charset does likewise.
+ */
+function ceo_escape_stored_text($value) {
+	$charset = get_option('blog_charset');
+	if (empty($charset)) $charset = 'UTF-8';
+	$decoded = html_entity_decode((string)$value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
+	return htmlspecialchars($decoded, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
+}
+
 function ceo_content_warning() {
 	return apply_filters('ceo-content-warning', __('Warning, Mature Content.','comiceasel'));
 }

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -109,6 +109,42 @@ function ceo_paypal_ipn_verify($ipn) {
 	return (trim(wp_remote_retrieve_body($response)) === 'VERIFIED');
 }
 
+/**
+ * The asking price for one cart line, taken from the server side only.
+ *
+ * The checkout form ships the price to the browser as a hidden field, so the
+ * buyer can change it before it ever reaches PayPal. This re-derives what the
+ * item should have cost from post meta, falling back to the plugin defaults --
+ * the same lookup ceo_display_buycomic() uses to build the form.
+ */
+function ceo_paypal_ipn_expected_amount($post_id, $item_name) {
+	if (strstr(strtolower($item_name), 'original')) {
+		$amount = get_post_meta($post_id, 'buy_print_orig_amount', true);
+		if ($amount === '' || $amount === false) $amount = ceo_pluginfo('buy_comic_orig_amount');
+	} else {
+		$amount = get_post_meta($post_id, 'buy_print_amount', true);
+		if ($amount === '' || $amount === false) $amount = ceo_pluginfo('buy_comic_print_amount');
+	}
+	return (float)preg_replace('/[^0-9.]/', '', (string)$amount);
+}
+
+/**
+ * Was this payment actually made to the site owner?
+ *
+ * The payee is a hidden form field too, so a buyer can redirect payment to
+ * their own account and still have PayPal send us a genuine notification.
+ * Sites that never configured an address, or left the shipped placeholder in
+ * place, have nothing to compare against and are not blocked.
+ */
+function ceo_paypal_ipn_payee_matches($ipn, $comiceasel_config) {
+	$expected = isset($comiceasel_config['buy_comic_email']) ? strtolower(trim($comiceasel_config['buy_comic_email'])) : '';
+	if (empty($expected) || $expected == 'yourname@yourpaypalemail.com') return true;
+	foreach (array('receiver_email', 'business') as $field) {
+		if (!empty($ipn[$field]) && strtolower(trim($ipn[$field])) == $expected) return true;
+	}
+	return false;
+}
+
 function ceo_paypal_ipn() {
 	// template_redirect fires for every front-end request, so this endpoint is
 	// reachable by anyone. The payload is hostile until PayPal confirms it sent
@@ -154,8 +190,27 @@ function ceo_paypal_ipn() {
 
 	$email_message = '';
 	$comiceasel_config = get_option('comiceasel-config');
+
+	// A VERIFIED response only proves PayPal sent the notification. It says
+	// nothing about who was paid or how much, both of which travel to PayPal as
+	// hidden fields the buyer controls. Re-check them against the server side.
+	$payee_ok = ceo_paypal_ipn_payee_matches($ipn, $comiceasel_config);
+
+	$expected_total = 0;
+	for ($i = 1; $i <= $num_cart_items; $i++) {
+		$pid = (int)$item_number[$i];
+		if ($pid) $expected_total += ceo_paypal_ipn_expected_amount($pid, $item_name[$i]);
+	}
+	// mc_gross is the cart total and includes shipping, so it may legitimately
+	// exceed the asking price -- only underpayment is rejected. A site with no
+	// prices recorded has nothing to compare against and is not blocked.
+	$amount_ok = ($expected_total <= 0) || (((float)$payment_amount + 0.001) >= $expected_total);
+
+	if (!$payee_ok) $email_message .= __('REJECTED: payment was not made to the configured PayPal address.','comiceasel')."\r\n\r\n";
+	if (!$amount_ok) $email_message .= sprintf(__('REJECTED: amount paid (%1$s) is below the asking price (%2$s).','comiceasel'), $payment_amount, $expected_total)."\r\n\r\n";
+
 	delete_option('ceo_paypal_receiver');
-	if ($payment_status == 'Completed') {
+	if ($payment_status == 'Completed' && $payee_ok && $amount_ok) {
 		$count = 1;
 		foreach ($item_number as $item_sub_number) {
 			$post_id = (int)$item_number[$count];

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -110,14 +110,6 @@ function ceo_paypal_ipn_verify($ipn) {
 }
 
 /**
- * The asking price for one cart line, taken from the server side only.
- *
- * The checkout form ships the price to the browser as a hidden field, so the
- * buyer can change it before it ever reaches PayPal. This re-derives what the
- * item should have cost from post meta, falling back to the plugin defaults --
- * the same lookup ceo_display_buycomic() uses to build the form.
- */
-/**
  * Is this cart line an original rather than a print?
  *
  * ceo_display_buycomic() builds the item name as "<Original|Print> - <title> - <id>", so
@@ -130,6 +122,14 @@ function ceo_paypal_ipn_is_original($item_name) {
 	return (strpos(strtolower((string)$item_name), $prefix) === 0);
 }
 
+/**
+ * The asking price for one cart line, taken from the server side only.
+ *
+ * The checkout form ships the price to the browser as a hidden field, so the
+ * buyer can change it before it ever reaches PayPal. This re-derives what the
+ * item should have cost from post meta, falling back to the plugin defaults --
+ * the same lookup ceo_display_buycomic() uses to build the form.
+ */
 function ceo_paypal_ipn_expected_amount($post_id, $item_name) {
 	if (ceo_paypal_ipn_is_original($item_name)) {
 		$amount = get_post_meta($post_id, 'buy_print_orig_amount', true);
@@ -225,6 +225,14 @@ function ceo_paypal_ipn() {
 		$pid = (int)$item_number[$i];
 		if ($pid) $expected_total += ceo_paypal_ipn_expected_amount($pid, $item_name[$i]);
 	}
+	// mc_gross is a bare number, so comparing it to the asking price is only
+	// meaningful once the currency matches. The buy form sends no currency_code,
+	// which means PayPal settles these carts in the account's default -- but a
+	// hand-built cart naming notify_url can pick any currency, and 65 JPY would
+	// otherwise satisfy a $65 asking price.
+	$expected_currency = strtoupper(apply_filters('ceo_paypal_expected_currency', 'USD'));
+	$currency_ok = ($payment_currency === '') || (strtoupper($payment_currency) === $expected_currency);
+
 	// mc_gross is the cart total and includes shipping, so it may legitimately
 	// exceed the asking price -- only underpayment is rejected. A site with no
 	// prices recorded has nothing to compare against and is not blocked.
@@ -232,9 +240,10 @@ function ceo_paypal_ipn() {
 
 	if (!$payee_ok) $email_message .= __('REJECTED: payment was not made to the configured PayPal address.','comiceasel')."\r\n\r\n";
 	if (!$amount_ok) $email_message .= sprintf(__('REJECTED: amount paid (%1$s) is below the asking price (%2$s).','comiceasel'), $payment_amount, $expected_total)."\r\n\r\n";
+	if (!$currency_ok) $email_message .= sprintf(__('REJECTED: payment currency (%1$s) is not %2$s.','comiceasel'), $payment_currency, $expected_currency)."\r\n\r\n";
 
 	delete_option('ceo_paypal_receiver');
-	if ($payment_status == 'Completed' && $payee_ok && $amount_ok) {
+	if ($payment_status == 'Completed' && $payee_ok && $amount_ok && $currency_ok) {
 		$count = 1;
 		foreach ($item_number as $item_sub_number) {
 			$post_id = (int)$item_number[$count];

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -191,9 +191,13 @@ function ceo_paypal_ipn() {
 	// PayPal retries notifications until the endpoint acknowledges them, and a
 	// captured notification can be replayed by hand, so act on each transaction
 	// exactly once.
+	// Key on the transaction AND its status: PayPal sends a fresh notification when a
+	// payment moves Pending -> Completed, and keying on txn_id alone would discard the
+	// Completed one as a duplicate, so the sale would never be recorded.
+	$txn_key = $txn_id.'|'.$payment_status;
 	$processed_txn = get_option('ceo_paypal_processed_txn', array());
 	if (!is_array($processed_txn)) $processed_txn = array();
-	if ($txn_id !== '' && in_array($txn_id, $processed_txn, true)) exit;
+	if ($txn_id !== '' && in_array($txn_key, $processed_txn, true)) exit;
 
 	$email_message = '';
 	$comiceasel_config = get_option('comiceasel-config');
@@ -261,7 +265,7 @@ function ceo_paypal_ipn() {
 				$email_message .= $post_info;
 			} */
 	if ($txn_id !== '') {
-		$processed_txn[] = $txn_id;
+		$processed_txn[] = $txn_key;
 		// Keep the ledger bounded; PayPal only retries for a few days.
 		if (count($processed_txn) > 500) $processed_txn = array_slice($processed_txn, -500);
 		update_option('ceo_paypal_processed_txn', $processed_txn, false);

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -188,6 +188,13 @@ function ceo_paypal_ipn() {
 	$address_country = isset($ipn['address_country']) ? $ipn['address_country'] : '';
 	$memo = isset($ipn['memo']) ? $ipn['memo'] : '';
 
+	// PayPal retries notifications until the endpoint acknowledges them, and a
+	// captured notification can be replayed by hand, so act on each transaction
+	// exactly once.
+	$processed_txn = get_option('ceo_paypal_processed_txn', array());
+	if (!is_array($processed_txn)) $processed_txn = array();
+	if ($txn_id !== '' && in_array($txn_id, $processed_txn, true)) exit;
+
 	$email_message = '';
 	$comiceasel_config = get_option('comiceasel-config');
 
@@ -253,6 +260,12 @@ function ceo_paypal_ipn() {
 	/*		foreach ($_POST as $post_info) {
 				$email_message .= $post_info;
 			} */
+	if ($txn_id !== '') {
+		$processed_txn[] = $txn_id;
+		// Keep the ledger bounded; PayPal only retries for a few days.
+		if (count($processed_txn) > 500) $processed_txn = array_slice($processed_txn, -500);
+		update_option('ceo_paypal_processed_txn', $processed_txn, false);
+	}
 	update_option('ceo_paypal_receiver', $email_message);
 	if (isset($comiceasel_config['buy_comic_email']))
 		wp_mail($comiceasel_config['buy_comic_email'], __('Comic Easel: Notification of Transaction - Buy Comic','comiceasel'), $email_message);

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -97,12 +97,21 @@ function ceo_random_comic() {
  * Anything that is not an explicit VERIFIED must be discarded.
  */
 function ceo_paypal_ipn_verify($ipn) {
+	// The notification is echoed back verbatim, except that cmd is ours and must stay ours.
+	// $ipn is attacker-supplied, so a naive array_merge() with $ipn second lets a posted
+	// cmd=_cart overwrite the validation command. That fails closed today, since PayPal will
+	// not answer VERIFIED to a request that is not a validation request, but it is one
+	// refactor away from being a bypass.
+	$body = $ipn;
+	unset($body['cmd']);
+	$body = array_merge(array('cmd' => '_notify-validate'), $body);
+
 	$endpoint = apply_filters('ceo_paypal_ipn_endpoint', 'https://ipnpb.paypal.com/cgi-bin/webscr');
 	$response = wp_remote_post($endpoint, array(
 			'timeout' => 30,
 			'httpversion' => '1.1',
 			'user-agent' => 'ComicEasel/'.ceo_pluginfo('version').'; '.home_url(),
-			'body' => array_merge(array('cmd' => '_notify-validate'), $ipn)
+			'body' => $body
 			));
 	if (is_wp_error($response)) return false;
 	if (wp_remote_retrieve_response_code($response) != 200) return false;

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -250,8 +250,19 @@ function ceo_paypal_ipn() {
 	// which means PayPal settles these carts in the account's default -- but a
 	// hand-built cart naming notify_url can pick any currency, and 65 JPY would
 	// otherwise satisfy a $65 asking price.
-	$expected_currency = strtoupper(apply_filters('ceo_paypal_expected_currency', 'USD'));
-	$currency_ok = ($payment_currency === '') || (strtoupper($payment_currency) === $expected_currency);
+	// Comparing mc_gross without the currency lets a payment in a weaker unit satisfy the
+	// asking price numerically. There is nothing to compare against, though: the plugin has no
+	// currency setting, and the buy form does not send one, so PayPal bills these carts in the
+	// receiving account's own primary currency -- which is not USD for a seller outside the US.
+	// Hardcoding a default would reject every legitimate sale for those sellers.
+	//
+	// So pin to whatever this site is actually paid in: remember the currency from the first
+	// notification that carries one, and require later payments to match it. The first payment
+	// after upgrading goes unchecked, which is no worse than the behaviour it replaces, and
+	// every payment after that is covered without anyone having to configure anything.
+	$expected_currency = strtoupper((string)apply_filters('ceo_paypal_expected_currency', get_option('ceo_paypal_currency', '')));
+	$payment_currency_uc = strtoupper((string)$payment_currency);
+	$currency_ok = ($payment_currency_uc === '') || ($expected_currency === '') || ($payment_currency_uc === $expected_currency);
 
 	// mc_gross is the cart total and includes shipping, so it may legitimately
 	// exceed the asking price -- only underpayment is rejected. A site with no
@@ -260,7 +271,7 @@ function ceo_paypal_ipn() {
 
 	if (!$payee_ok) $email_message .= __('REJECTED: payment was not made to the configured PayPal address.','comiceasel')."\r\n\r\n";
 	if (!$amount_ok) $email_message .= sprintf(__('REJECTED: amount paid (%1$s) is below the asking price (%2$s).','comiceasel'), $payment_amount, $expected_total)."\r\n\r\n";
-	if (!$currency_ok) $email_message .= sprintf(__('REJECTED: payment currency (%1$s) is not %2$s.','comiceasel'), $payment_currency, $expected_currency)."\r\n\r\n";
+	if (!$currency_ok) $email_message .= sprintf(__('REJECTED: payment currency (%1$s) is not the %2$s this site is normally paid in.','comiceasel'), $payment_currency, $expected_currency)."\r\n\r\n";
 
 	delete_option('ceo_paypal_receiver');
 	if ($payment_status == 'Completed' && $payee_ok && $amount_ok && $currency_ok) {
@@ -306,6 +317,10 @@ function ceo_paypal_ipn() {
 	/*		foreach ($_POST as $post_info) {
 				$email_message .= $post_info;
 			} */
+	// Remember the currency this site is paid in, so later payments can be checked against it.
+	if ($currency_ok && $payment_currency_uc !== '' && $expected_currency === '') {
+		update_option('ceo_paypal_currency', $payment_currency_uc, false);
+	}
 	if ($txn_id !== '') {
 		$processed_txn[] = $txn_key;
 		// Keep the ledger bounded; PayPal only retries for a few days.

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -147,12 +147,16 @@ function ceo_paypal_ipn_is_original($item_name) {
  * the same lookup ceo_display_buycomic() uses to build the form.
  */
 function ceo_paypal_ipn_expected_amount($post_id, $item_name) {
+	// empty() rather than a === comparison, to match how ceo_display_buycomic() and the meta
+	// box decide whether to fall back to the configured default. Diverging here would mean a
+	// stored '0' showed the default price on the form but expected 0.00 from the payment,
+	// which disables the amount check for the whole cart.
 	if (ceo_paypal_ipn_is_original($item_name)) {
 		$amount = get_post_meta($post_id, 'buy_print_orig_amount', true);
-		if ($amount === '' || $amount === false) $amount = ceo_pluginfo('buy_comic_orig_amount');
+		if (empty($amount)) $amount = ceo_pluginfo('buy_comic_orig_amount');
 	} else {
 		$amount = get_post_meta($post_id, 'buy_print_amount', true);
-		if ($amount === '' || $amount === false) $amount = ceo_pluginfo('buy_comic_print_amount');
+		if (empty($amount)) $amount = ceo_pluginfo('buy_comic_print_amount');
 	}
 	return (float)preg_replace('/[^0-9.]/', '', (string)$amount);
 }

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -127,8 +127,15 @@ function ceo_paypal_ipn_verify($ipn) {
  * purchase look like an original.
  */
 function ceo_paypal_ipn_is_original($item_name) {
-	$prefix = strtolower(__('Original','comiceasel')).' - ';
-	return (strpos(strtolower((string)$item_name), $prefix) === 0);
+	$item_name = strtolower((string)$item_name);
+	// Match the translated label AND the untranslated one. The item name was built when the
+	// form rendered, but __() here resolves in whatever locale is active when the
+	// notification arrives -- change the site language between those two moments and every
+	// original would otherwise be misread as a print.
+	foreach (array(strtolower(__('Original','comiceasel')), 'original') as $label) {
+		if (strpos($item_name, $label.' - ') === 0) return true;
+	}
+	return false;
 }
 
 /**

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -89,110 +89,118 @@ function ceo_random_comic() {
 	exit;
 }
 
+/**
+ * Post an IPN payload back to PayPal and report whether PayPal owns it.
+ *
+ * PayPal requires the notification be echoed back verbatim, with
+ * cmd=_notify-validate first, and answers with either VERIFIED or INVALID.
+ * Anything that is not an explicit VERIFIED must be discarded.
+ */
+function ceo_paypal_ipn_verify($ipn) {
+	$endpoint = apply_filters('ceo_paypal_ipn_endpoint', 'https://ipnpb.paypal.com/cgi-bin/webscr');
+	$response = wp_remote_post($endpoint, array(
+			'timeout' => 30,
+			'httpversion' => '1.1',
+			'user-agent' => 'ComicEasel/'.ceo_pluginfo('version').'; '.home_url(),
+			'body' => array_merge(array('cmd' => '_notify-validate'), $ipn)
+			));
+	if (is_wp_error($response)) return false;
+	if (wp_remote_retrieve_response_code($response) != 200) return false;
+	return (trim(wp_remote_retrieve_body($response)) === 'VERIFIED');
+}
+
 function ceo_paypal_ipn() {
-	$req = 'cmd=_notify-validate';
-	// Get each element of IPN request
+	// template_redirect fires for every front-end request, so this endpoint is
+	// reachable by anyone. The payload is hostile until PayPal confirms it sent
+	// it -- nothing below may touch the database or send mail before that.
+	$ipn = array();
 	foreach ($_POST as $key => $value) {
-		$value = urlencode(stripslashes($value));
-		$req .= "&$key=$value";
+		if (is_scalar($value)) $ipn[$key] = wp_unslash($value);
 	}
-	$header = '';
-	$header .= "POST /cgi-bin/webscr HTTP/1.0\r\n";
-	$header .= "Content-Type: application/x-www-form-urlencoded\r\n";
-	$header .= "Content-Length: " . strlen($req) . "\r\n\r\n";
-	$fp = fsockopen ('www.paypal.com', 80, $errno, $errstr, 30);
-	// assign posted variables to local variables
-	$num_cart_items = (isset($_POST['num_cart_items'])) ? (int)$_POST['num_cart_items'] : '1';
+	if (empty($ipn) || !ceo_paypal_ipn_verify($ipn)) exit;
+
+	// The cart size is attacker-supplied even on a verified notification, so
+	// clamp it rather than looping on whatever number arrived.
+	$num_cart_items = isset($ipn['num_cart_items']) ? (int)$ipn['num_cart_items'] : 1;
+	if ($num_cart_items < 1) $num_cart_items = 1;
+	$max_cart_items = apply_filters('ceo_paypal_max_cart_items', 100);
+	if ($num_cart_items > $max_cart_items) $num_cart_items = $max_cart_items;
+
 	$count = 1;
 	$item_name = array();
 	$item_number = array();
 	while ($count <= $num_cart_items) {
-		$item_name[$count] = (isset($_POST['item_name'.$count])) ? $_POST['item_name'.$count] : '';
-		$item_number[$count] = (isset($_POST['item_number'.$count])) ? $_POST['item_number'.$count] : '';
+		$item_name[$count] = isset($ipn['item_name'.$count]) ? $ipn['item_name'.$count] : '';
+		$item_number[$count] = isset($ipn['item_number'.$count]) ? $ipn['item_number'.$count] : '';
 		$count++;
 	}
-	
-	$payment_status = (isset($_POST['payment_status'])) ? $_POST['payment_status'] : '';
-	$payment_amount = (isset($_POST['mc_gross'])) ? $_POST['mc_gross'] : '';
-	$payment_currency = (isset($_POST['mc_currency'])) ? $_POST['mc_currency'] : '';
-	$txn_id = (isset($_POST['txn_id'])) ? $_POST['txn_id'] : '';
-	$shipping = (isset($_POST['shipping'])) ? $_POST['shipping'] : '';
-	//	$receiver_email = (isset($_POST['receiver_email'])) ? $_POST['txn_id'] : '';
-	$business = (isset($_POST['business'])) ? $_POST['business'] : '';
-	$payer_email = (isset($_POST['payer_email'])) ? $_POST['payer_email'] : '';
-	$first_name = (isset($_POST['first_name'])) ? $_POST['first_name'] : '';
-	$last_name = (isset($_POST['last_name'])) ? $_POST['last_name'] : '';
-	$address_name = (isset($_POST['address_name'])) ? $_POST['address_name'] : '';
-	$address_street = (isset($_POST['address_street'])) ? $_POST['address_street'] : '';
-	$address_city = (isset($_POST['address_city'])) ? $_POST['address_city'] : '';
-	$address_state = (isset($_POST['address_state'])) ? $_POST['address_state'] : '';
-	$address_zip = (isset($_POST['address_zip'])) ? $_POST['address_zip'] : '';
-	$address_country = (isset($_POST['address_country'])) ? $_POST['address_country'] : '';
-	$memo = (isset($_POST['memo'])) ? $_POST['memo'] : '';
-	
+
+	$payment_status = isset($ipn['payment_status']) ? $ipn['payment_status'] : '';
+	$payment_amount = isset($ipn['mc_gross']) ? $ipn['mc_gross'] : '';
+	$payment_currency = isset($ipn['mc_currency']) ? $ipn['mc_currency'] : '';
+	$txn_id = isset($ipn['txn_id']) ? $ipn['txn_id'] : '';
+	$shipping = isset($ipn['shipping']) ? $ipn['shipping'] : '';
+	$business = isset($ipn['business']) ? $ipn['business'] : '';
+	$payer_email = isset($ipn['payer_email']) ? $ipn['payer_email'] : '';
+	$first_name = isset($ipn['first_name']) ? $ipn['first_name'] : '';
+	$last_name = isset($ipn['last_name']) ? $ipn['last_name'] : '';
+	$address_name = isset($ipn['address_name']) ? $ipn['address_name'] : '';
+	$address_street = isset($ipn['address_street']) ? $ipn['address_street'] : '';
+	$address_city = isset($ipn['address_city']) ? $ipn['address_city'] : '';
+	$address_state = isset($ipn['address_state']) ? $ipn['address_state'] : '';
+	$address_zip = isset($ipn['address_zip']) ? $ipn['address_zip'] : '';
+	$address_country = isset($ipn['address_country']) ? $ipn['address_country'] : '';
+	$memo = isset($ipn['memo']) ? $ipn['memo'] : '';
+
 	$email_message = '';
 	$comiceasel_config = get_option('comiceasel-config');
 	delete_option('ceo_paypal_receiver');
-	if (!$fp) {
-		$email_message .= "HTTP Error - Host could not connect to paypal.\r\n";
-	} else {
-		fputs($fp, $header . $req);
-		$res = '';
-		while (!feof($fp)) {
-			$res .= fgets($fp, 1024);
-		}
-		if ($payment_status == 'Completed') {
-			$comiceasel_options = get_option('comiceasel_options');
-			$count = 1;
-			foreach ($item_number as $item_sub_number) {
-				$post_id = (int)$item_number[$count];
-				if (strstr(strtolower($item_name[$count]), 'original')) {
-					$post_id = (int)$item_number[$count];
-					update_post_meta($post_id, 'buyorig-status', __('Sold','comiceasel'));
-					$email_message .= 'Comic ID #'.$post_id." Set to SOLD\r\n\r\n";
-					// Flush the cache on the item in question.
-					if (defined('WP_CACHE') && WP_CACHE == true) {
-						wp_cache_no_postid($post_id);
-					}
-				}
-				$count++;
-			}
-		} elseif (strcmp($res,"INVALID") == 0) {
-			$email_message .= "Invalid Transaction\r\n";
-		}
-		$email_message .= __('Transaction URL','comiceasel').': '.home_url()."\r\n";
-		$email_message .= __('Number Items','comiceasel').': '.$num_cart_items."\r\n";
+	if ($payment_status == 'Completed') {
 		$count = 1;
-		foreach ($item_name as $item_sub_name) {
-			$email_message .= __('Item Name','comiceasel').' ['.$count.']: '.$item_sub_name."\r\n";
-			$email_message .= __('Item Number','comiceasel').' ['.$count.']: '.$item_number[$count]."\r\n";
+		foreach ($item_number as $item_sub_number) {
+			$post_id = (int)$item_number[$count];
+			if ($post_id && strstr(strtolower($item_name[$count]), 'original')) {
+				update_post_meta($post_id, 'buyorig-status', __('Sold','comiceasel'));
+				$email_message .= 'Comic ID #'.$post_id." Set to SOLD\r\n\r\n";
+				// Flush the cache on the item in question.
+				if (defined('WP_CACHE') && WP_CACHE == true && function_exists('wp_cache_no_postid')) {
+					wp_cache_no_postid($post_id);
+				}
+			}
 			$count++;
 		}
-		$email_message .= __('Payment Status','comiceasel').': '.$payment_status."\r\n";
-		$email_message .= __('Payment Amount','comiceasel').': '.$payment_amount."\r\n";
-		$email_message .= __('Shipping','comiceasel').': '.$shipping."\r\n";
-		$email_message .= __('Payment Currency','comiceasel').': '.$payment_currency."\r\n";
-		$email_message .= __('TXN_ID','comiceasel').': '.$txn_id."\r\n";
-		$email_message .= __('Paypal Receiver','comiceasel').': '.$business."\r\n\r\n";
-		
-		$email_message .= __('Payer Name','comiceasel').': '.$first_name.' '.$last_name."\r\n";
-		$email_message .= __('Payer Email','comiceasel').': '.$payer_email."\r\n\r\n";
-		
-		$email_message .= __('to Name','comiceasel').': '.$address_name."\r\n";
-		$email_message .= __('Street','comiceasel').': '.$address_street."\r\n";
-		$email_message .= __('City','comiceasel').': '.$address_city."\r\n";
-		$email_message .= __('State','comiceasel').': '.$address_state."\r\n";
-		$email_message .= __('Zip','comiceasel').': '.$address_zip."\r\n";
-		$email_message .= __('Country','comiceasel').': '.$address_country."\r\n\r\n";
-		if (!empty($memo)) $email_message .= __('Memo','comiceasel').': '.$memo."\r\n";
-		/*		foreach ($_POST as $post_info) {
-					$email_message .= $post_info;
-				} */
-		update_option('ceo_paypal_receiver', $email_message);
-		if (isset($comiceasel_config['buy_comic_email'])) 
-			wp_mail($comiceasel_config['buy_comic_email'], __('Comic Easel: Notification of Transaction - Buy Comic','comiceasel'), $email_message);		
 	}
-	fclose ($fp);				
+	$email_message .= __('Transaction URL','comiceasel').': '.home_url()."\r\n";
+	$email_message .= __('Number Items','comiceasel').': '.$num_cart_items."\r\n";
+	$count = 1;
+	foreach ($item_name as $item_sub_name) {
+		$email_message .= __('Item Name','comiceasel').' ['.$count.']: '.$item_sub_name."\r\n";
+		$email_message .= __('Item Number','comiceasel').' ['.$count.']: '.$item_number[$count]."\r\n";
+		$count++;
+	}
+	$email_message .= __('Payment Status','comiceasel').': '.$payment_status."\r\n";
+	$email_message .= __('Payment Amount','comiceasel').': '.$payment_amount."\r\n";
+	$email_message .= __('Shipping','comiceasel').': '.$shipping."\r\n";
+	$email_message .= __('Payment Currency','comiceasel').': '.$payment_currency."\r\n";
+	$email_message .= __('TXN_ID','comiceasel').': '.$txn_id."\r\n";
+	$email_message .= __('Paypal Receiver','comiceasel').': '.$business."\r\n\r\n";
+	
+	$email_message .= __('Payer Name','comiceasel').': '.$first_name.' '.$last_name."\r\n";
+	$email_message .= __('Payer Email','comiceasel').': '.$payer_email."\r\n\r\n";
+	
+	$email_message .= __('to Name','comiceasel').': '.$address_name."\r\n";
+	$email_message .= __('Street','comiceasel').': '.$address_street."\r\n";
+	$email_message .= __('City','comiceasel').': '.$address_city."\r\n";
+	$email_message .= __('State','comiceasel').': '.$address_state."\r\n";
+	$email_message .= __('Zip','comiceasel').': '.$address_zip."\r\n";
+	$email_message .= __('Country','comiceasel').': '.$address_country."\r\n\r\n";
+	if (!empty($memo)) $email_message .= __('Memo','comiceasel').': '.$memo."\r\n";
+	/*		foreach ($_POST as $post_info) {
+				$email_message .= $post_info;
+			} */
+	update_option('ceo_paypal_receiver', $email_message);
+	if (isset($comiceasel_config['buy_comic_email']))
+		wp_mail($comiceasel_config['buy_comic_email'], __('Comic Easel: Notification of Transaction - Buy Comic','comiceasel'), $email_message);
 	exit;
 }
 

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -117,8 +117,21 @@ function ceo_paypal_ipn_verify($ipn) {
  * item should have cost from post meta, falling back to the plugin defaults --
  * the same lookup ceo_display_buycomic() uses to build the form.
  */
+/**
+ * Is this cart line an original rather than a print?
+ *
+ * ceo_display_buycomic() builds the item name as "<Original|Print> - <title> - <id>", so
+ * match the leading label rather than searching the whole string: the title sits inside
+ * the same field, and a comic called "The Original Sin" would otherwise make every print
+ * purchase look like an original.
+ */
+function ceo_paypal_ipn_is_original($item_name) {
+	$prefix = strtolower(__('Original','comiceasel')).' - ';
+	return (strpos(strtolower((string)$item_name), $prefix) === 0);
+}
+
 function ceo_paypal_ipn_expected_amount($post_id, $item_name) {
-	if (strstr(strtolower($item_name), 'original')) {
+	if (ceo_paypal_ipn_is_original($item_name)) {
 		$amount = get_post_meta($post_id, 'buy_print_orig_amount', true);
 		if ($amount === '' || $amount === false) $amount = ceo_pluginfo('buy_comic_orig_amount');
 	} else {
@@ -225,7 +238,7 @@ function ceo_paypal_ipn() {
 		$count = 1;
 		foreach ($item_number as $item_sub_number) {
 			$post_id = (int)$item_number[$count];
-			if ($post_id && strstr(strtolower($item_name[$count]), 'original')) {
+			if ($post_id && ceo_paypal_ipn_is_original($item_name[$count])) {
 				update_post_meta($post_id, 'buyorig-status', __('Sold','comiceasel'));
 				$email_message .= 'Comic ID #'.$post_id." Set to SOLD\r\n\r\n";
 				// Flush the cache on the item in question.

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -355,6 +355,13 @@ function ceo_the_transcript($displaymode = 'raw') {
 	global $post;
 	$transcript = get_post_meta( $post->ID, "transcript", true );
 	apply_filters('ceo_the_transcript_raw', $transcript);
+	// A transcript is plain text and every display mode below emits it into the
+	// page. The stored value arrives in two shapes -- entity-encoded when it was
+	// written through the Comic Easel meta box, which escapes on save, and raw
+	// when it was written through WordPress's Custom Fields panel, which does
+	// not. Decoding first normalises both, so the escape below applies exactly
+	// once: legacy values render as they always did, raw markup stops executing.
+	$transcript = esc_html(html_entity_decode((string)$transcript, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401));
 	if (!empty($transcript)) {			
 		switch ($displaymode) {
 			case "raw":

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -361,11 +361,7 @@ function ceo_the_transcript($displaymode = 'raw') {
 	// when it was written through WordPress's Custom Fields panel, which does
 	// not. Decoding first normalises both, so the escape below applies exactly
 	// once: legacy values render as they always did, raw markup stops executing.
-	// htmlspecialchars() rather than esc_html(), because esc_html() declines to
-	// re-encode text that already looks like an entity. A transcript containing the
-	// literal characters &lt;b&gt; would lose a level of encoding on every render and
-	// eventually display as <b>.
-	$transcript = htmlspecialchars(html_entity_decode((string)$transcript, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401), ENT_QUOTES, get_option('blog_charset'));
+	$transcript = ceo_escape_stored_text($transcript);
 	if (!empty($transcript)) {			
 		switch ($displaymode) {
 			case "raw":

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -361,7 +361,11 @@ function ceo_the_transcript($displaymode = 'raw') {
 	// when it was written through WordPress's Custom Fields panel, which does
 	// not. Decoding first normalises both, so the escape below applies exactly
 	// once: legacy values render as they always did, raw markup stops executing.
-	$transcript = esc_html(html_entity_decode((string)$transcript, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401));
+	// htmlspecialchars() rather than esc_html(), because esc_html() declines to
+	// re-encode text that already looks like an entity. A transcript containing the
+	// literal characters &lt;b&gt; would lose a level of encoding on every render and
+	// eventually display as <b>.
+	$transcript = htmlspecialchars(html_entity_decode((string)$transcript, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401), ENT_QUOTES, get_option('blog_charset'));
 	if (!empty($transcript)) {			
 		switch ($displaymode) {
 			case "raw":

--- a/tests/ComicHtmlTrustTest.php
+++ b/tests/ComicHtmlTrustTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * ceo_comic_html_for_output() — functions/displaycomic.php
+ *
+ * The comic-html-above / comic-html-below fields are meant to hold markup, so their contents
+ * cannot simply be escaped. Whether they are filtered instead depends on whether WordPress
+ * would trust the people involved with raw HTML.
+ *
+ * Filtering happens at render rather than on save, deliberately: these meta keys are
+ * unprotected on a post type declaring custom-fields support, so WordPress's own Custom
+ * Fields panel writes them without ever passing through the plugin's save handler. A
+ * save-time check would miss that path, and would also miss everything already in the
+ * database.
+ *
+ * wp_kses_post() is stubbed as a recorder returning a sentinel, so these tests assert the
+ * trust DECISION rather than re-implementing what kses strips.
+ */
+class ComicHtmlTrustTest extends CE_TestCase {
+
+	const AUTHOR = 7;
+	const EDITOR = 9;
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/displaycomic.php' );
+	}
+
+	private function post( $author = self::AUTHOR, $id = 1 ) {
+		$post              = new stdClass();
+		$post->ID          = $id;
+		$post->post_author = $author;
+		return $post;
+	}
+
+	private function assertWasFiltered( $result ) {
+		$this->assertStringStartsWith( CE_KSES_SENTINEL, $result, 'value should have been filtered' );
+	}
+
+	private function assertWasNotFiltered( $result ) {
+		$this->assertStringStartsNotWith( CE_KSES_SENTINEL, $result, 'value should have been returned as written' );
+		$this->assertSame( array(), CE_Test_State::$kses_calls );
+	}
+
+	public function testMarkupFromAnUntrustedAuthorIsFiltered() {
+		$out = ceo_comic_html_for_output( '<script>alert(1)</script>', $this->post() );
+		$this->assertWasFiltered( $out );
+	}
+
+	public function testMarkupFromATrustedAuthorIsLeftAlone() {
+		$this->grantCap( self::AUTHOR, 'unfiltered_html' );
+		$out = ceo_comic_html_for_output( '<iframe src="x"></iframe>', $this->post() );
+		$this->assertWasNotFiltered( $out );
+	}
+
+	/**
+	 * The case this function exists to catch. On multisite an Editor does not hold
+	 * unfiltered_html but can still edit an administrator's comic, so trusting the recorded
+	 * post author alone let their markup through unfiltered.
+	 */
+	public function testMarkupIsFilteredWhenAnUntrustedUserEditedATrustedAuthorsComic() {
+		$this->grantCap( self::AUTHOR, 'unfiltered_html' );
+		$this->setPostMeta( 1, '_edit_last', self::EDITOR );
+		$out = ceo_comic_html_for_output( '<script>alert(1)</script>', $this->post() );
+		$this->assertWasFiltered( $out );
+	}
+
+	public function testMarkupIsLeftAloneWhenBothAuthorAndLastEditorAreTrusted() {
+		$this->grantCap( self::AUTHOR, 'unfiltered_html' );
+		$this->grantCap( self::EDITOR, 'unfiltered_html' );
+		$this->setPostMeta( 1, '_edit_last', self::EDITOR );
+		$out = ceo_comic_html_for_output( '<b>fine</b>', $this->post() );
+		$this->assertWasNotFiltered( $out );
+	}
+
+	public function testLastEditorBeingTheAuthorIsNotTreatedAsASecondUser() {
+		$this->grantCap( self::AUTHOR, 'unfiltered_html' );
+		$this->setPostMeta( 1, '_edit_last', (string) self::AUTHOR );
+		$out = ceo_comic_html_for_output( '<b>fine</b>', $this->post() );
+		$this->assertWasNotFiltered( $out );
+	}
+
+	public function testAnUnknownPostIsFiltered() {
+		$this->assertWasFiltered( ceo_comic_html_for_output( '<script>x</script>', null ) );
+	}
+
+	public function testAnAuthorlessPostIsFiltered() {
+		$post = $this->post( 0 );
+		$this->assertWasFiltered( ceo_comic_html_for_output( '<script>x</script>', $post ) );
+	}
+
+	/**
+	 * Ordering matters and is easy to get wrong: the stored value is decoded BEFORE the trust
+	 * decision, so an entity-encoded payload from an untrusted author must still reach kses
+	 * as live markup rather than sneaking past as inert text.
+	 */
+	public function testEncodedMarkupIsDecodedBeforeBeingFiltered() {
+		ceo_comic_html_for_output( '&lt;script&gt;alert(1)&lt;/script&gt;', $this->post() );
+		$this->assertSame( array( '<script>alert(1)</script>' ), CE_Test_State::$kses_calls );
+	}
+
+	/** Only one level of encoding is peeled, so a doubly-encoded value stays inert. */
+	public function testOnlyOneLevelOfEncodingIsDecoded() {
+		ceo_comic_html_for_output( '&amp;lt;script&amp;gt;', $this->post() );
+		$this->assertSame( array( '&lt;script&gt;' ), CE_Test_State::$kses_calls );
+	}
+}

--- a/tests/EscapeStoredTextTest.php
+++ b/tests/EscapeStoredTextTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * ceo_escape_stored_text() — functions/library.php
+ *
+ * The shared escaper for comic meta rendered as HTML text. Two things about it are easy to
+ * get wrong and neither is visible on inspection, which is why they are pinned here.
+ */
+class EscapeStoredTextTest extends CE_TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/library.php' );
+	}
+
+	/**
+	 * A single invalid UTF-8 byte must not blank the value.
+	 *
+	 * From PHP 8.1 the default flag set for htmlspecialchars() is
+	 * ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401. Passing ENT_QUOTES alone replaces that
+	 * default instead of adding to it, dropping ENT_SUBSTITUTE — and without it a malformed
+	 * byte makes htmlspecialchars() return an empty string. A transcript with one stray byte
+	 * would render as nothing at all.
+	 */
+	public function testInvalidUtf8DoesNotBlankTheValue() {
+		$out = ceo_escape_stored_text( "Panel one\x80 and two" );
+		$this->assertNotSame( '', $out );
+		$this->assertStringContainsString( 'Panel one', $out );
+		$this->assertStringContainsString( 'and two', $out );
+	}
+
+	/** An empty or unrecognised blog_charset must not blank the value either. */
+	#[DataProvider( 'badCharsetProvider' )]
+	public function testUnusableBlogCharsetDoesNotBlankTheValue( $charset ) {
+		CE_Test_State::$options['blog_charset'] = $charset;
+		$this->assertStringContainsString( 'Panel one', ceo_escape_stored_text( 'Panel one' ) );
+	}
+
+	public static function badCharsetProvider() {
+		return array(
+			'empty'  => array( '' ),
+			'false'  => array( false ),
+			'null'   => array( null ),
+		);
+	}
+
+	/**
+	 * Rendering must be stable across saves: a value stored the way the meta boxes store it
+	 * must come back as exactly those bytes. See the header of functions/library.php for why
+	 * esc_html() cannot be used here.
+	 */
+	#[DataProvider( 'authoredTextProvider' )]
+	public function testRenderingIsStableAcrossSaves( $typed ) {
+		$stored = esc_textarea( $typed );
+		$this->assertSame( $stored, ceo_escape_stored_text( $stored ) );
+	}
+
+	public static function authoredTextProvider() {
+		return array(
+			'markup shown as text'            => array( '<b>bold</b>' ),
+			'an entity typed literally'       => array( '&lt;b&gt;' ),
+			'a bare ampersand'                => array( 'Tom & Jerry' ),
+			'an ampersand already escaped'    => array( 'Tom &amp; Jerry' ),
+			'quotes'                          => array( 'she said "hi"' ),
+			'an apostrophe'                   => array( "it's fine" ),
+		);
+	}
+
+	/** Raw markup written past the meta boxes must come out inert. */
+	public function testRawMarkupIsNeutralised() {
+		$out = ceo_escape_stored_text( '<script>alert(1)</script>' );
+		$this->assertStringNotContainsString( '<script', $out );
+		$this->assertSame( '&lt;script&gt;alert(1)&lt;/script&gt;', $out );
+	}
+
+	public function testAttributeBreakingCharactersAreEscaped() {
+		$this->assertSame( '&quot;', ceo_escape_stored_text( '"' ) );
+		$this->assertSame( '&#039;', ceo_escape_stored_text( "'" ) );
+	}
+
+	#[DataProvider( 'nonStringProvider' )]
+	public function testNonStringInputIsHandled( $input, $expected ) {
+		$this->assertSame( $expected, ceo_escape_stored_text( $input ) );
+	}
+
+	public static function nonStringProvider() {
+		return array(
+			array( null, '' ),
+			array( false, '' ),
+			array( 123, '123' ),
+		);
+	}
+}

--- a/tests/MetaForEditorTest.php
+++ b/tests/MetaForEditorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * ceo_meta_for_editor() — functions/admin-meta.php
+ *
+ * Normalises a stored comic meta value before it is re-displayed in the post editor. Comic
+ * meta arrives in two shapes -- entity-encoded when written through the plugin's meta boxes,
+ * which escape on save, and raw when written through WordPress's Custom Fields panel, which
+ * does not. Decoding first is what makes a single escape at the output sink correct for both.
+ */
+class MetaForEditorTest extends CE_TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/admin-meta.php' );
+	}
+
+	/**
+	 * The property the meta boxes depend on: a value stored the way the save handler stores
+	 * it, then normalised and re-escaped for a textarea, must come back byte-identical. If
+	 * this fails, every existing comic shows mangled text in the editor.
+	 */
+	#[DataProvider( 'authoredTextProvider' )]
+	public function testTextareaRoundTripIsLossless( $typed ) {
+		$stored = esc_textarea( $typed );
+		$this->assertSame( $stored, esc_textarea( ceo_meta_for_editor( $stored ) ) );
+	}
+
+	/** And the value the author actually typed is what they see again. */
+	#[DataProvider( 'authoredTextProvider' )]
+	public function testTheAuthorSeesWhatTheyTyped( $typed ) {
+		$this->assertSame( $typed, ceo_meta_for_editor( esc_textarea( $typed ) ) );
+	}
+
+	public static function authoredTextProvider() {
+		return array(
+			'markup'                       => array( '<b>bold</b>' ),
+			'an entity typed literally'    => array( '&lt;b&gt;' ),
+			'a bare ampersand'             => array( 'Tom & Jerry' ),
+			'quotes'                       => array( 'she said "hi"' ),
+			'an apostrophe'                => array( "it's fine" ),
+			'a url with a query string'    => array( 'https://x.test/?a=1&b=2' ),
+		);
+	}
+
+	/**
+	 * A raw value written past the meta boxes must not survive as live markup once the sink
+	 * escapes it. This is the Custom Fields path.
+	 */
+	public function testRawMarkupFromCustomFieldsBecomesInert() {
+		$raw = '</textarea><script>alert(1)</script>';
+		$out = esc_textarea( ceo_meta_for_editor( $raw ) );
+		$this->assertStringNotContainsString( '</textarea>', $out );
+		$this->assertStringNotContainsString( '<script', $out );
+	}
+
+	public function testAttributeBreakingValueBecomesInert() {
+		$out = esc_attr( ceo_meta_for_editor( '" autofocus onfocus="alert(1)' ) );
+		$this->assertStringNotContainsString( '"', str_replace( '&quot;', '', $out ) );
+	}
+
+	#[DataProvider( 'decodingProvider' )]
+	public function testKnownEntitiesAreDecodedOnce( $stored, $expected ) {
+		$this->assertSame( $expected, ceo_meta_for_editor( $stored ) );
+	}
+
+	public static function decodingProvider() {
+		return array(
+			array( '&lt;b&gt;', '<b>' ),
+			array( '&amp;amp;', '&amp;' ),
+			array( '&quot;x&quot;', '"x"' ),
+			array( '&#039;', "'" ),
+			array( '<b>', '<b>' ),
+			array( '&notanentity;', '&notanentity;' ),
+		);
+	}
+
+	#[DataProvider( 'nonStringProvider' )]
+	public function testNonStringInputIsHandled( $input, $expected ) {
+		$this->assertSame( $expected, ceo_meta_for_editor( $input ) );
+	}
+
+	public static function nonStringProvider() {
+		return array(
+			array( null, '' ),
+			array( false, '' ),
+			array( 123, '123' ),
+		);
+	}
+}

--- a/tests/PaypalIpnTest.php
+++ b/tests/PaypalIpnTest.php
@@ -97,4 +97,43 @@ class PaypalIpnTest extends CE_TestCase {
 		ceo_paypal_ipn_verify( array( 'txn_id' => '1' ) );
 		$this->assertSame( 'http://localhost:8081/stub.php', CE_Test_State::$http_requests[1]['url'] );
 	}
+
+	/* ---------------------------------------------------------------- *
+	 * ceo_paypal_ipn_is_original()
+	 * ---------------------------------------------------------------- */
+
+	#[DataProvider( 'itemNameProvider' )]
+	public function testOriginalIsIdentifiedByTheLeadingLabel( $item_name, $expected ) {
+		$this->assertSame( $expected, ceo_paypal_ipn_is_original( $item_name ) );
+	}
+
+	public static function itemNameProvider() {
+		return array(
+			'an original'                   => array( 'Original - My Comic - 12', true ),
+			'case insensitive'              => array( 'ORIGINAL - My Comic - 12', true ),
+			// The bug this test exists for: the comic title sits inside the item name, so a
+			// substring search found "original" in the title and priced every print as an
+			// original.
+			'a print of a comic titled "The Original Sin"' => array( 'Print - The Original Sin - 12', false ),
+			'a plain print'                 => array( 'Print - My Comic - 12', false ),
+			'a similar word'                => array( 'Originals - x', false ),
+			'missing the separator'         => array( 'Original- x', false ),
+			'leading whitespace'            => array( ' Original - x', false ),
+			'empty'                         => array( '', false ),
+			'null'                          => array( null, false ),
+			'numeric'                       => array( 123, false ),
+		);
+	}
+
+	/**
+	 * The item name is built when the form renders, but __() here resolves when the
+	 * notification arrives. Both labels must work, or changing the site language silently
+	 * reprices every original already on sale.
+	 */
+	public function testBothTranslatedAndUntranslatedLabelsAreRecognised() {
+		CE_Test_State::$translations['Original'] = 'Origineel';
+		$this->assertTrue( ceo_paypal_ipn_is_original( 'Origineel - My Comic - 12' ) );
+		$this->assertTrue( ceo_paypal_ipn_is_original( 'Original - My Comic - 12' ) );
+		$this->assertFalse( ceo_paypal_ipn_is_original( 'Print - My Comic - 12' ) );
+	}
 }

--- a/tests/PaypalIpnTest.php
+++ b/tests/PaypalIpnTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The PayPal IPN validation helpers — functions/redirects.php
+ *
+ * These decide whether an unauthenticated POST to /?ceopaypalipn is allowed to mark artwork
+ * as sold. ceo_paypal_ipn() itself cannot be unit-tested — every path out of it ends in
+ * exit(), which is a language construct and cannot be stubbed — which is exactly why the
+ * decisions were extracted into these four functions.
+ */
+class PaypalIpnTest extends CE_TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/redirects.php' );
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * ceo_paypal_ipn_verify()
+	 * ---------------------------------------------------------------- */
+
+	private function paypalReplies( $body, $code = 200 ) {
+		CE_Test_State::$http_response = array(
+			'body'     => $body,
+			'response' => array( 'code' => $code ),
+		);
+	}
+
+	#[DataProvider( 'verifiedBodyProvider' )]
+	public function testOnlyAnExplicitVerifiedIsAccepted( $body, $expected ) {
+		$this->paypalReplies( $body );
+		$this->assertSame( $expected, ceo_paypal_ipn_verify( array( 'txn_id' => '1' ) ) );
+	}
+
+	public static function verifiedBodyProvider() {
+		return array(
+			'exact'             => array( 'VERIFIED', true ),
+			'trailing newline'  => array( "VERIFIED\n", true ),
+			'surrounding space' => array( '  VERIFIED  ', true ),
+			'lowercase'         => array( 'verified', false ),
+			'suffixed'          => array( 'VERIFIEDX', false ),
+			'invalid'           => array( 'INVALID', false ),
+			'empty'             => array( '', false ),
+			'html error page'   => array( '<html>error</html>', false ),
+		);
+	}
+
+	public function testANonOkResponseIsRejectedEvenWhenTheBodySaysVerified() {
+		$this->paypalReplies( 'VERIFIED', 500 );
+		$this->assertFalse( ceo_paypal_ipn_verify( array( 'txn_id' => '1' ) ) );
+	}
+
+	public function testATransportErrorIsRejected() {
+		CE_Test_State::$http_response = new WP_Error( 'http', 'could not connect' );
+		$this->assertFalse( ceo_paypal_ipn_verify( array( 'txn_id' => '1' ) ) );
+	}
+
+	/**
+	 * PayPal only recognises the notification if it is echoed back unchanged. The original
+	 * implementation of this handler urlencoded and stripslashed every field first, which is
+	 * part of why validation never worked.
+	 */
+	public function testTheNotificationIsEchoedBackVerbatim() {
+		$this->paypalReplies( 'VERIFIED' );
+		$ipn = array(
+			'txn_id'         => 'ABC123',
+			'payment_status' => 'Completed',
+			'address_street' => "12 O'Connell St",
+			'mc_gross'       => '65.00',
+		);
+		ceo_paypal_ipn_verify( $ipn );
+
+		$sent = CE_Test_State::$http_requests[0]['args']['body'];
+		foreach ( $ipn as $key => $value ) {
+			$this->assertSame( $value, $sent[ $key ], "$key must be echoed back unchanged" );
+		}
+	}
+
+	public function testTheValidationCommandIsSentFirstAndCannotBeOverwritten() {
+		$this->paypalReplies( 'VERIFIED' );
+		// cmd is attacker-controlled: it arrives in the same POST as everything else.
+		ceo_paypal_ipn_verify( array( 'cmd' => '_cart', 'txn_id' => '1' ) );
+
+		$sent = CE_Test_State::$http_requests[0]['args']['body'];
+		$this->assertSame( '_notify-validate', $sent['cmd'] );
+		$this->assertSame( 'cmd', array_key_first( $sent ), 'PayPal expects cmd first' );
+	}
+
+	public function testTheEndpointDefaultsToPaypalAndIsFilterable() {
+		$this->paypalReplies( 'VERIFIED' );
+		ceo_paypal_ipn_verify( array( 'txn_id' => '1' ) );
+		$this->assertSame( 'https://ipnpb.paypal.com/cgi-bin/webscr', CE_Test_State::$http_requests[0]['url'] );
+
+		CE_Test_State::$filters['ceo_paypal_ipn_endpoint'] = 'http://localhost:8081/stub.php';
+		ceo_paypal_ipn_verify( array( 'txn_id' => '1' ) );
+		$this->assertSame( 'http://localhost:8081/stub.php', CE_Test_State::$http_requests[1]['url'] );
+	}
+}

--- a/tests/PaypalIpnTest.php
+++ b/tests/PaypalIpnTest.php
@@ -136,4 +136,83 @@ class PaypalIpnTest extends CE_TestCase {
 		$this->assertTrue( ceo_paypal_ipn_is_original( 'Original - My Comic - 12' ) );
 		$this->assertFalse( ceo_paypal_ipn_is_original( 'Print - My Comic - 12' ) );
 	}
+
+	/* ---------------------------------------------------------------- *
+	 * ceo_paypal_ipn_expected_amount()
+	 * ---------------------------------------------------------------- */
+
+	public function testOriginalAndPrintPricesComeFromTheirOwnMetaKeys() {
+		$this->setPostMeta( 7, 'buy_print_orig_amount', '65.00' );
+		$this->setPostMeta( 7, 'buy_print_amount', '25.00' );
+
+		$this->assertSame( 65.0, ceo_paypal_ipn_expected_amount( 7, 'Original - x - 7' ) );
+		$this->assertSame( 25.0, ceo_paypal_ipn_expected_amount( 7, 'Print - x - 7' ) );
+	}
+
+	public function testPriceFallsBackToTheConfiguredDefault() {
+		CE_Test_State::$pluginfo['buy_comic_orig_amount']  = '80.00';
+		CE_Test_State::$pluginfo['buy_comic_print_amount'] = '30.00';
+
+		$this->assertSame( 80.0, ceo_paypal_ipn_expected_amount( 7, 'Original - x - 7' ) );
+		$this->assertSame( 30.0, ceo_paypal_ipn_expected_amount( 7, 'Print - x - 7' ) );
+	}
+
+	/**
+	 * A stored '0' must fall back to the configured default, because that is what the buy
+	 * form and the meta box both do. Diverging would mean the form advertised one price while
+	 * the IPN expected 0.00 — which switches the amount check off for the entire cart.
+	 */
+	public function testAStoredZeroFallsBackTheSameWayTheFormDoes() {
+		$this->setPostMeta( 7, 'buy_print_orig_amount', '0' );
+		CE_Test_State::$pluginfo['buy_comic_orig_amount'] = '65.00';
+		$this->assertSame( 65.0, ceo_paypal_ipn_expected_amount( 7, 'Original - x - 7' ) );
+	}
+
+	#[DataProvider( 'messyAmountProvider' )]
+	public function testAmountsAreParsedLeniently( $stored, $expected ) {
+		$this->setPostMeta( 7, 'buy_print_amount', $stored );
+		$this->assertSame( $expected, ceo_paypal_ipn_expected_amount( 7, 'Print - x - 7' ) );
+	}
+
+	public static function messyAmountProvider() {
+		return array(
+			'thousands separator' => array( '$1,299.00', 1299.0 ),
+			'currency suffix'     => array( '65.00 USD', 65.0 ),
+			'plain'               => array( '42', 42.0 ),
+			'not a number'        => array( 'abc', 0.0 ),
+		);
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * ceo_paypal_ipn_payee_matches()
+	 * ---------------------------------------------------------------- */
+
+	public function testPayeeMatchesOnEitherReceiverEmailOrBusiness() {
+		$config = array( 'buy_comic_email' => 'me@example.com' );
+
+		$this->assertTrue( ceo_paypal_ipn_payee_matches( array( 'receiver_email' => ' ME@Example.com ' ), $config ) );
+		$this->assertTrue( ceo_paypal_ipn_payee_matches( array( 'business' => 'me@example.com' ), $config ) );
+		$this->assertFalse( ceo_paypal_ipn_payee_matches( array( 'receiver_email' => 'thief@evil.test' ), $config ) );
+		$this->assertFalse( ceo_paypal_ipn_payee_matches( array(), $config ) );
+	}
+
+	/**
+	 * The checks fail open where there is nothing to compare against, so a half-configured
+	 * shop is not broken by this. That is a deliberate trade-off and worth pinning, because
+	 * it means these sites accept a payment made to anybody.
+	 */
+	#[DataProvider( 'unconfiguredPayeeProvider' )]
+	public function testPayeeCheckFailsOpenWhenNothingIsConfigured( $config ) {
+		$this->assertTrue( ceo_paypal_ipn_payee_matches( array( 'receiver_email' => 'anyone@evil.test' ), $config ) );
+	}
+
+	public static function unconfiguredPayeeProvider() {
+		return array(
+			'option never saved'      => array( false ),
+			'key absent'             => array( array() ),
+			'empty string'           => array( array( 'buy_comic_email' => '' ) ),
+			'shipped placeholder'    => array( array( 'buy_comic_email' => 'yourname@yourpaypalemail.com' ) ),
+			'placeholder, odd case'  => array( array( 'buy_comic_email' => 'YourName@YourPayPalEmail.com' ) ),
+		);
+	}
 }

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -89,9 +89,42 @@ Reachable with no theme support at all, via shortcodes on an ordinary page:
 
 ## The PayPal endpoint
 
-`POST /?ceopaypalipn` talks to PayPal directly, with the hostname written into the code, so
-there is no supported way to exercise it against a local stub. Testing it means either
-editing that hostname in a scratch copy or using a PayPal sandbox account.
+`POST /?ceopaypalipn` discards anything PayPal does not confirm with a literal `VERIFIED`, so
+it cannot be exercised without either a PayPal sandbox account or a local stand-in. Three
+filters exist to make the local route possible; drop this in `wp-content/mu-plugins/`:
+
+```php
+<?php
+// Answer the verification handshake ourselves.
+add_filter( 'ceo_paypal_ipn_endpoint', function () {
+	return 'http://127.0.0.1:8080/ipn-stub.php'; // a file that echoes: VERIFIED
+} );
+
+// Capture the notification email instead of sending it.
+add_filter( 'pre_wp_mail', function ( $null, $atts ) {
+	file_put_contents( WP_CONTENT_DIR . '/ce-mail.log', json_encode( $atts ) . "\n", FILE_APPEND );
+	return true;
+}, 10, 2 );
+```
+
+`ceo_paypal_expected_currency` (default `USD`) and `ceo_paypal_max_cart_items` are filterable
+too.
+
+Then POST to `/?ceopaypalipn` directly. The reject paths matter as much as the accept path,
+because each should say *why* in the notification email rather than silently doing nothing:
+
+| Case | Expected |
+|---|---|
+| stub answers anything but `VERIFIED` | nothing written, no mail |
+| valid: right payee, currency and amount | comic marked Sold, owner emailed |
+| `business` is not the configured address | not sold, "REJECTED: payment was not made to the configured PayPal address." |
+| `mc_currency` is not the expected currency | not sold, "REJECTED: payment currency ... is not USD." |
+| `mc_gross` below the asking price | not sold, "REJECTED: amount paid ... is below the asking price" |
+| same `txn_id` and status replayed | ignored, no second mail |
+| `Pending` then `Completed`, same `txn_id` | both processed; the `Completed` one marks it Sold |
+
+That last row is worth keeping: the ledger is keyed on transaction *and* status precisely so a
+Pending notification cannot swallow the Completed one that follows it.
 
 ## Always
 


### PR DESCRIPTION
Third in the series, following #38 and #39.

Unlike #39, **these fixes can change what an existing site does**, which is why they were held back into their own PR. Every commit that alters behaviour carries a `NOTE FOR UPGRADERS` paragraph explaining what changes and for whom.

## What's in it

**The PayPal notification endpoint.** It acted on the contents of a notification without checking PayPal's response, so the verification step it appeared to perform had no effect. It now requires an explicit `VERIFIED` before reading or writing anything, over TLS via `wp_remote_post()` rather than a cleartext socket. On top of that it re-derives the price and payee server-side (both travel to PayPal as hidden form fields the buyer controls), pins the currency, and records settled transactions so a notification is acted on once.

**Comic HTML, transcript and the editor meta boxes.** The two HTML fields were emitted through `html_entity_decode()`, which undid the escaping applied when they were saved and handed the result to the browser as live markup. These meta keys are also unprotected on a post type declaring `custom-fields` support, so WordPress's own Custom Fields panel writes them without going through the plugin's save handler at all. Output now applies WordPress's normal trust rule, and the meta boxes escape what they display.

The escaping had to be done carefully: values already in the database are entity-encoded, so escaping them again would render a stored `<b>` as literal `&lt;b&gt;` text on every existing comic. Each sink decodes first and then escapes once.

## Testing

CI covers `php -l` on PHP 7.4–8.4, PHPUnit on 8.2–8.4, PHPCS on changed lines. The unit suite grew from 60 to 144 tests.

Beyond that, on a real WordPress (7.0, MySQL 9.7, PHP 8.5, `WP_DEBUG` on), with two comics — one authored by an Author-role user, one by an administrator:

**The editor keeps showing existing content unchanged.** This was the main regression risk. Values in the shape the meta box saves them display byte-identically before and after, checked by reading each field's decoded value out of the DOM:

| field | `master` | this branch |
|---|---|---|
| `comic-html-above` | `<b>bold</b> & "quoted" <em>x</em>` | identical |
| `transcript` | `Line one\nHe said "hi" & left <b>fast</b>` | identical |
| `comic-hovertext` | `hover "text" & more` | identical |
| `refer-only-msg` | `Come from <b>partner</b> "site"` | identical |

**Values written through the Custom Fields panel stop breaking the editor.** With `</textarea><script>…</script>` stored in `comic-html-below` and `520" onmouseover="…` in `flash_width`, on `master` the edit screen shows the first field as *empty* (the content escaped its textarea), truncates the second at the quote, and ends up with one injected `<script>` element and one live event handler — both of which run in the administrator's session. On this branch both values sit inside their fields, no script element is injected, and nothing runs.

**The trust rule behaves as documented.** Same `<script>` in `comic-html-above` on both comics:

- comic authored by the Author-role user → 0 script elements, script does not run, `<b>` markup preserved
- comic authored by the administrator → renders as written and runs, so the feature still works for people trusted with raw HTML

**The notification endpoint**, against a local stub standing in for PayPal, each case starting from a clean state:

| case | result |
|---|---|
| stub answers anything but `VERIFIED` | not sold |
| correct payee, currency and amount | sold |
| paid to a different address | not sold, reason in the email |
| currency the site is not normally paid in | not sold, reason in the email |
| below the asking price | not sold, reason in the email |
| same transaction replayed | ignored, one email |
| `Pending` then `Completed` | not sold, then sold |

### One thing changed during this testing

The currency check originally defaulted to USD, reasoning that the buy form does not send a currency. That reasoning was wrong — PayPal bills these carts in the receiving account's **own** primary currency, so the check would have rejected every legitimate sale for any seller outside the US, with no setting for them to correct it. It now remembers the currency the site is actually paid in from the first notification carrying one and requires later payments to match, which needs no configuration and breaks nobody. Verified with a GBP-only seller: first payment accepted and pinned, later GBP payments accepted, a JPY payment rejected.

I checked how much this matters in practice before changing it: of 203 live Comic Easel installs, 2 actually render `[buycomic]`, and one of those is an active store. Small, but not zero.
