### PR TITLE
Replace lapsed Comic Easel links

### DIFF
--- a/ceo-admin.php
+++ b/ceo-admin.php
@@ -5,9 +5,6 @@ if (!defined('ABSPATH')) exit;
 add_action('admin_menu', 'ceo_add_menu_pages');
 add_action('admin_enqueue_scripts', 'ceo_comic_editor_scripts', 10, 1 );
 
-if (ceo_pluginfo('add_dashboard_frumph_feed_widget'))
-	add_action('wp_dashboard_setup', 'ceo_add_dashboard_widgets' );
-
 function ceo_comic_editor_scripts( $hook ) {
 	global $pagenow, $post;
 	if (!empty($pagenow)) {
@@ -100,18 +97,6 @@ function ceo_import() {
 	require_once('ceo-import.php');
 }
 
-/**
- * This set of functions is for displaying the dashboard feed widget.
- *
- */
-function ceo_dashboard_feed_widget() {
-	wp_widget_rss_output('https://comiceasel.com/?feed=rss2', array('items' => 3, 'show_summary' => true));
-} 
-
-function ceo_add_dashboard_widgets() {
-	wp_add_dashboard_widget('ceo_dashboard_widget', 'Comic Easel News', 'ceo_dashboard_feed_widget');	
-}
-
 function ceo_enqueue_admin_cpt_style( $cpt, $handle, $src = false, $deps = array(), $ver = false, $media = 'all' ) {
  
 	/* Check the admin page we are on. */
@@ -136,4 +121,3 @@ function ceo_enqueue_admin_cpt_style( $cpt, $handle, $src = false, $deps = array
 	/* Only enqueue if editor page is the correct CPT. */
 	if ($enqueue) wp_enqueue_style( $handle, $src, $deps, $ver, $media );
 }
-

--- a/ceo-config.php
+++ b/ceo-config.php
@@ -44,7 +44,6 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 			}
 
 			foreach (array(
-				'add_dashboard_frumph_feed_widget',
 				'disable_comic_on_home_page',
 				'disable_comic_blog_on_home_page',
 				'enable_comments_on_homepage',
@@ -221,7 +220,7 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 
 	<div class="ceoadmin-footer">
 		<br />
-		<a href="http://comiceasel.com"><?php _e('Comic Easel','comiceasel'); ?></a> <?php _e('created, developed and maintained by','comiceasel'); ?> <a href="http://frumph.net/">Philip M. Hofer</a> <small>(<a href="http://frumph.net/">Frumph</a>)</small><br />
+		<a href="https://github.com/Frumph/comic-easel"><?php _e('Comic Easel','comiceasel'); ?></a> <?php _e('created, developed and maintained by','comiceasel'); ?> <a href="http://frumph.net/">Philip M. Hofer</a> <small>(<a href="http://frumph.net/">Frumph</a>)</small><br />
 		<?php _e('If you like the Comic Easel plugin, please donate.  It will help in developing new features and versions.','comiceasel'); ?><br />
 		<table style="margin:0 auto;">
 			<tr>
@@ -243,4 +242,3 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 			</tr>
 		</table>
 	</div>
-

--- a/comiceasel.php
+++ b/comiceasel.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Comic Easel
-Plugin URI: http://comiceasel.com
+Plugin URI: https://github.com/Frumph/comic-easel
 Description: Comic Easel allows you to incorporate a WebComic using the WordPress Media Library functionality with Navigation into almost all WordPress themes. With just a few modifications of adding injection do_action locations into a theme, you can have the theme of your choice display and manage a webcomic.
 Version: 1.17
 Author: Philip M. Hofer (Frumph)
@@ -371,7 +371,6 @@ function ceo_load_options($reset = false) {
 		$ceo_config = array();
 		foreach (array(
 			'db_version' => '1.2',
-			'add_dashboard_frumph_feed_widget' => true,
 			'disable_comic_on_home_page' => false,
 			'disable_comic_blog_on_home_page' => false,
 			'click_comic_next' => true,

--- a/lang/comiceasel-en_US.po
+++ b/lang/comiceasel-en_US.po
@@ -1192,16 +1192,6 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: options/general.php:12
-#@ comic-easel
-msgid "Enable Dashboard Feed to ComicEasel.com"
-msgstr ""
-
-#: options/general.php:17
-#@ comic-easel
-msgid "This is a feed that shows what is happening on ComicEasel.com"
-msgstr ""
-
 #: options/general.php:21
 #@ comic-easel
 msgid "Disable Comic on the Home Page?"
@@ -2078,19 +2068,19 @@ msgstr ""
 msgid "Technical Support"
 msgstr ""
 
-#: options/main.php:11
+#: options/main.php:12
 #@ comic-easel
-msgid "probably has the answer you're looking for in the form of a post or in the faqs section."
+msgid "Comic Easel project and support:"
+msgstr ""
+
+#: options/main.php:17
+#@ comic-easel
+msgid "GitHub Issues:"
 msgstr ""
 
 #: options/main.php:14
 #@ comic-easel
 msgid "(best chances to reach me at the top going down to the least chance)"
-msgstr ""
-
-#: options/main.php:16
-#@ comic-easel
-msgid "Form Email:"
 msgstr ""
 
 #: options/main.php:17
@@ -2329,11 +2319,6 @@ msgstr ""
 msgid "The thumbnail for the direct comic and chapter RSS /comic/feed/ and /chapter/chapter-slug/feed/"
 msgstr ""
 
-#: options/main.php:11
-#@ comic-easel
-msgid "The Comic Easel website:"
-msgstr ""
-
 #: options/main.php:13
 #@ comic-easel
 msgid "You can contact me for technical support at any of the following locations:"
@@ -2363,4 +2348,3 @@ msgstr ""
 #@ comic-easel
 msgid "Try to have Comic Easel automatically remove the featured image in posts on non-ComicPress themes?"
 msgstr ""
-

--- a/options/general.php
+++ b/options/general.php
@@ -9,15 +9,6 @@
 						<th colspan="3"><?php _e('Configuration','comiceasel'); ?></th>
 					</tr>
 				</thead>
-				<tr class="alternate">
-					<th scope="row"><label for="add_dashboard_frumph_feed_widget"><?php _e('Enable Dashboard Feed to ComicEasel.com','comiceasel'); ?></label></th>
-					<td>
-						<input id="add_dashboard_frumph_feed_widget" name="add_dashboard_frumph_feed_widget" type="checkbox" value="1" <?php checked(true, $ceo_options['add_dashboard_frumph_feed_widget']); ?> />
-					</td>
-					<td>
-						<?php _e('This is a feed that shows what is happening on ComicEasel.com','comiceasel'); ?>
-					</td>
-				</tr>
 				<tr>
 					<th scope="row"><label for="disable_comic_on_home_page"><?php _e('Disable Comic on the Home Page?','comiceasel'); ?></label></th>
 					<td>

--- a/options/main.php
+++ b/options/main.php
@@ -9,12 +9,12 @@
 				</thead>
 				<tr>
 					<td>
-						<?php _e('The Comic Easel website:','comiceasel'); ?>&nbsp;<a href="http://comiceasel.com">http://comiceasel.com</a>&nbsp;<?php _e('probably has the answer you\'re looking for in the form of a post or in the faqs section.','comiceasel'); ?><br />
+						<?php _e('Comic Easel project and support:','comiceasel'); ?>&nbsp;<a href="https://github.com/Frumph/comic-easel">https://github.com/Frumph/comic-easel</a><br />
 						<br />
 						<?php _e('You can contact me for technical support at any of the following locations:','comiceasel'); ?><br />
 						<em><?php _e('(best chances to reach me at the top going down to the least chance)','comiceasel'); ?></em><br />
 						<br />
-						<?php _e('Form Email:','comiceasel'); ?> <a href="http://comiceasel.com/contact/">http://comiceasel.com/contact/</a><br />
+						<?php _e('GitHub Issues:', 'comiceasel'); ?> <a href="https://github.com/Frumph/comic-easel/issues">https://github.com/Frumph/comic-easel/issues</a><br />
 						<?php _e('Via Facebook:','comiceasel'); ?> <a href="http://facebook.com/philip.hofer">http://facebook.com/philip.hofer</a><br />
 						<?php _e('WebComics.COM Forums:', 'comiceasel'); ?> <a href="http://webcomics.com/forum/website-design-assistance/">http://webcomics.com/forum/website-design-assistance/</a>  <?php _e('(Subscription only)','comiceasel'); ?><br />
 						<?php _e('WordPress.ORG Forums:', 'comiceasel'); ?> <a href="https://wordpress.org/support/plugin/comic-easel">https://wordpress.org/support/plugin/comic-easel</a> <?php _e('(rarely go here)','comiceasel'); ?><br />

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ Comic Easel allows you to post webcomics to your theme.
 
 == Description ==
 
-Comic Easel Website: [Comic Easel](http://comiceasel.com/ "Comic Easel - Plugin your WebComic")
+Comic Easel project: [Comic Easel on GitHub](https://github.com/Frumph/comic-easel)
 
 Comic Easel allows you to incorporate a WebComic using the WordPress Media Library functionality with Navigation into almost any WordPress theme. With just a few modifications of adding *injection* action locations into a theme, you can have the theme of your choice display a comic.
 
@@ -117,7 +117,7 @@ Sidebars for Comic Easel are added automatically since 05/28/2012 They should ap
 
 == Frequently Asked Questions ==
 
-Comic Easel Website, Troubleshoot Page: [Comic Easel](http://comiceasel.com/faqs/troubleshoot/ "Comic Easel - Plugin your Website - Troubleshooting Comic Easel")
+Project and support: [Comic Easel on GitHub](https://github.com/Frumph/comic-easel)
 
 = The permalinks are not working to go to the comic =
 
@@ -396,7 +396,7 @@ The comic navigation widget is only seen if you have the comic sidebar's enabled
 * shuffle some logic around in the casthover widget so it doesn't display title if there are no cast members set
 
 = 1.4 =
-* Added support for 'motion artist' comics.   Read documentation at comiceasel.com
+* Added support for 'motion artist' comics.
 * Fixed some visual issues on the comic - comics page, where the thumbnail was being cut off
 * made the admin-editor.css file enqueue on the comics list page as well
 * added 'this day in history' to the thumbnail widget, needs testing
@@ -437,7 +437,7 @@ The comic navigation widget is only seen if you have the comic sidebar's enabled
 * Comic blog post widget now has an Ordering based on the option in the config.  
 
 = 1.3.8 =
-* Revamped the cast-page shortcode, in tables now, also shows most recent comic the character was in, cast-page now accepts order=(asc/desc) and limit=# arguments documentation now available at comiceasel.com
+* Revamped the cast-page shortcode, in tables now, also shows most recent comic the character was in, cast-page now accepts order=(asc/desc) and limit=# arguments
 
 = 1.3.7 =
 * New debug screen for variables and system information. (for me to help people with mainly)

--- a/widgets/archive-dropdown.php
+++ b/widgets/archive-dropdown.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Comic Archive Dropdown
-Widget URI: http://comiceasel.org/
+Widget URI: https://github.com/Frumph/comic-easel
 Description: Display a list of links of the latest comics.
 Author: Philip M. Hofer (Frumph)
 Version: 1.1
@@ -205,4 +205,3 @@ class ceo_comic_archive_dropdown_widget extends WP_Widget {
 		<?php
 	}
 }
-

--- a/widgets/comicblogpost.php
+++ b/widgets/comicblogpost.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Comic Blog Post Widget
-Widget URI: http://comiceasel.com
+Widget URI: https://github.com/Frumph/comic-easel
 Description: Display's the comic's blog post.
 Author: Philip M. Hofer (Frumph)
 Author URI: http://frumph.net/
@@ -106,4 +106,3 @@ class ceo_comic_blog_post_widget extends WP_Widget {
 		<?php
 	}
 }
-

--- a/widgets/comiclist-dropdown.php
+++ b/widgets/comiclist-dropdown.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Comic List Dropdown of Current Chapter
-Widget URI: http://comiceasel.org/
+Widget URI: https://github.com/Frumph/comic-easel
 Description: Display a list of links of the latest comics.
 Author: Philip M. Hofer (Frumph)
 Version: 1.02
@@ -98,4 +98,3 @@ class ceo_comic_list_dropdown_widget extends WP_Widget {
 		<?php
 	}
 }
-

--- a/widgets/navigation.php
+++ b/widgets/navigation.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Graphical Navigation
-Widget URI: http://comiceasel.com/
+Widget URI: https://github.com/Frumph/comic-easel
 Description: You can place graphical navigation buttons on your comic.
 Author: Philip M. Hofer (Frumph) (mods by Chris Maverick)
 Author URI: http://frumph.net/
@@ -365,4 +365,3 @@ class ceo_comic_navigation_widget extends WP_Widget {
 		<?php
 	}
 }
-

--- a/widgets/recentcomics.php
+++ b/widgets/recentcomics.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Latest Comics Widget
-Widget URI: http://comiceasel.org/
+Widget URI: https://github.com/Frumph/comic-easel
 Description: Display a list of links of the latest comics.
 Author: Philip M. Hofer (Frumph)
 Version: 1.02
@@ -62,4 +62,3 @@ class ceo_latest_comics_widget extends WP_Widget {
 		<?php
 	}
 }
-

--- a/widgets/scheduledcomics.php
+++ b/widgets/scheduledcomics.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Widget Name: Scheduled Posts
-Widget URI: http://comiceasel.com/
+Widget URI: https://github.com/Frumph/comic-easel
 Description: Display a list of comic posts that are due to be scheduled.
 Author: Philip M. Hofer (Frumph)
 Author URI: http://frumph.net/
@@ -63,4 +63,3 @@ class ceo_scheduled_comics_widget extends WP_Widget {
 		<?php
 	}
 }
-


### PR DESCRIPTION
`ComicEasel.com` has lapsed, so the plugin should no longer send administrators there or contact its old RSS endpoint. This replaces useful project links with the upstream GitHub repository and removes the dead dashboard feed entirely.

## What changed

- `Plugin URI`, widget metadata, readme links, and admin project links now point to `https://github.com/Frumph/comic-easel`
- the Technical Support contact list now leads with `https://github.com/Frumph/comic-easel/issues`
- the Comic Easel News dashboard RSS widget, its setting, default, save handling, and translation strings are removed
- the dead contact-form link is removed
- historical changelog facts are preserved while their obsolete documentation clauses are removed

## Upgrade compatibility

An existing `add_dashboard_frumph_feed_widget` option may remain in the shared options array, but nothing reads it or performs the remote request. Leaving it inert avoids rewriting unrelated legacy settings during upgrade.

This PR remains limited to the lapsed-domain cleanup; the Blind Ferret removal is already in `master` via #42.

## Testing

- `composer test` — 141 tests, 190 assertions
- `composer lint:php` — all PHP files pass
- gettext catalog validation exits successfully (the catalog's pre-existing missing `Language` header warning remains)
- targeted repository scan — no `comiceasel.com` or `comiceasel.org` reference remains

Co-authored by gpt-5.6-sol.
