### PR TITLE
Harden PayPal IPN validation and require explicit currency

### DIFF
--- a/ceo-config.php
+++ b/ceo-config.php
@@ -149,6 +149,9 @@ if ( isset($_POST['_wpnonce']) && wp_verify_nonce($_POST['_wpnonce'], 'update-op
 							$ceo_options[$key] = '';
 			}
 
+			$currency = isset($_REQUEST['buy_comic_currency']) ? strtoupper(trim(sanitize_text_field(wp_unslash($_REQUEST['buy_comic_currency'])))) : '';
+			$ceo_options['buy_comic_currency'] = preg_match('/^[A-Z]{3}$/', $currency) ? $currency : '';
+
 			foreach (array(
 				'enable_buy_comic',
 				'buy_comic_sell_print',

--- a/comiceasel.php
+++ b/comiceasel.php
@@ -401,6 +401,7 @@ function ceo_load_options($reset = false) {
 			'enable_hoverbox' => false,
 			'enable_buy_comic' => false,
 			'buy_comic_email' => 'yourname@yourpaypalemail.com',
+			'buy_comic_currency' => 'USD',
 			'buy_comic_url' => home_url().'/shop/',
 			'buy_comic_sell_print' => false,
 			'buy_comic_print_amount' => '25.00',
@@ -494,6 +495,14 @@ function ceo_pluginfo($whichinfo = null) {
 		}
 		if (version_compare($ceo_options['db_version'], '1.9.8', '<')) {
 			$ceo_options['db_version'] = '1.9.8';
+			update_option('comiceasel-config', $ceo_options);
+		}
+		if (version_compare($ceo_options['db_version'], '1.9.9', '<')) {
+			$ceo_options['db_version'] = '1.9.9';
+			$currency = isset($ceo_options['buy_comic_currency']) ? strtoupper(trim((string)$ceo_options['buy_comic_currency'])) : '';
+			// Existing stores previously relied on the PayPal account's implicit currency.
+			// Do not guess and risk charging in the wrong one; the owner must choose it once.
+			$ceo_options['buy_comic_currency'] = preg_match('/^[A-Z]{3}$/', $currency) ? $currency : '';
 			update_option('comiceasel-config', $ceo_options);
 		}
 		$ceo_coreinfo = wp_upload_dir();

--- a/functions/redirects.php
+++ b/functions/redirects.php
@@ -128,13 +128,26 @@ function ceo_paypal_ipn_verify($ipn) {
  * purchase look like an original.
  */
 function ceo_paypal_ipn_is_original($item_name) {
+	return ceo_paypal_ipn_item_type($item_name) === 'original';
+}
+
+/**
+ * Resolve the product type from the label Comic Easel put at the start of an item name.
+ *
+ * PayPal returns the item name that was submitted with the cart. Only the two labels the
+ * plugin itself creates are valid; treating every unknown value as a print disables several
+ * server-side checks.
+ */
+function ceo_paypal_ipn_item_type($item_name) {
 	$item_name = strtolower((string)$item_name);
-	// Match the translated label AND the untranslated one. The item name was built when the
-	// form rendered, but __() here resolves in whatever locale is active when the
-	// notification arrives -- change the site language between those two moments and every
-	// original would otherwise be misread as a print.
-	foreach (array(strtolower(__('Original','comiceasel')), 'original') as $label) {
-		if (strpos($item_name, $label.' - ') === 0) return true;
+	$labels = array(
+		'original' => array(strtolower(__('Original','comiceasel')), 'original'),
+		'print' => array(strtolower(__('Print','comiceasel')), 'print')
+	);
+	foreach ($labels as $type => $type_labels) {
+		foreach (array_unique($type_labels) as $label) {
+			if ($label !== '' && strpos($item_name, $label.' - ') === 0) return $type;
+		}
 	}
 	return false;
 }
@@ -152,12 +165,15 @@ function ceo_paypal_ipn_expected_amount($post_id, $item_name) {
 	// box decide whether to fall back to the configured default. Diverging here would mean a
 	// stored '0' showed the default price on the form but expected 0.00 from the payment,
 	// which disables the amount check for the whole cart.
-	if (ceo_paypal_ipn_is_original($item_name)) {
+	$item_type = ceo_paypal_ipn_item_type($item_name);
+	if ($item_type === 'original') {
 		$amount = get_post_meta($post_id, 'buy_print_orig_amount', true);
 		if (empty($amount)) $amount = ceo_pluginfo('buy_comic_orig_amount');
-	} else {
+	} elseif ($item_type === 'print') {
 		$amount = get_post_meta($post_id, 'buy_print_amount', true);
 		if (empty($amount)) $amount = ceo_pluginfo('buy_comic_print_amount');
+	} else {
+		return 0.0;
 	}
 	return (float)preg_replace('/[^0-9.]/', '', (string)$amount);
 }
@@ -167,23 +183,106 @@ function ceo_paypal_ipn_expected_amount($post_id, $item_name) {
  *
  * The payee is a hidden form field too, so a buyer can redirect payment to
  * their own account and still have PayPal send us a genuine notification.
- * Sites that never configured an address, or left the shipped placeholder in
- * place, have nothing to compare against and are not blocked.
+ * A missing address cannot be verified, so it must fail closed.
  */
 function ceo_paypal_ipn_payee_matches($ipn, $comiceasel_config) {
-	$expected = isset($comiceasel_config['buy_comic_email']) ? strtolower(trim($comiceasel_config['buy_comic_email'])) : '';
-	if (empty($expected) || $expected == 'yourname@yourpaypalemail.com') return true;
+	$expected = ceo_paypal_merchant($comiceasel_config);
+	if ($expected === '') return false;
 	foreach (array('receiver_email', 'business') as $field) {
 		if (!empty($ipn[$field]) && strtolower(trim($ipn[$field])) == $expected) return true;
 	}
 	return false;
 }
 
+function ceo_paypal_merchant($comiceasel_config) {
+	if (!is_array($comiceasel_config)) return '';
+	$merchant = isset($comiceasel_config['buy_comic_email']) ? strtolower(trim((string)$comiceasel_config['buy_comic_email'])) : '';
+	return ($merchant === '' || $merchant === 'yourname@yourpaypalemail.com') ? '' : $merchant;
+}
+
+/**
+ * Return the explicit currency shared by the checkout form and IPN validator.
+ */
+function ceo_paypal_currency($comiceasel_config) {
+	$currency = is_array($comiceasel_config) && isset($comiceasel_config['buy_comic_currency'])
+		? strtoupper(trim((string)$comiceasel_config['buy_comic_currency']))
+		: '';
+	$currency = strtoupper(trim((string)apply_filters('ceo_paypal_expected_currency', $currency)));
+	return preg_match('/^[A-Z]{3}$/', $currency) ? $currency : '';
+}
+
+/**
+ * Validate one cart line entirely against server-side state.
+ *
+ * Returning the normalized values lets the endpoint validate the whole cart before it
+ * performs any writes.
+ */
+function ceo_paypal_ipn_validate_item($post_id, $item_name, $comiceasel_config) {
+	$post_id = (int)$post_id;
+	$item_type = ceo_paypal_ipn_item_type($item_name);
+	if ($post_id < 1 || !$item_type || !is_array($comiceasel_config)) return false;
+
+	$post = get_post($post_id);
+	if (empty($post) || is_wp_error($post) || $post->post_type !== 'comic' || $post->post_status !== 'publish') return false;
+	if (!empty($post->post_password)) return false;
+
+	$sell_key = ($item_type === 'original') ? 'buy_comic_sell_original' : 'buy_comic_sell_print';
+	if (empty($comiceasel_config[$sell_key])) return false;
+
+	$status_key = ($item_type === 'original') ? 'buyorig-status' : 'buyprint-status';
+	$status = get_post_meta($post_id, $status_key, true);
+	if ($status !== '' && !in_array($status, array(__('Available','comiceasel'), 'Available'), true)) return false;
+
+	$amount = ceo_paypal_ipn_expected_amount($post_id, $item_name);
+	if (!is_finite($amount) || $amount <= 0) return false;
+
+	return array(
+		'post_id' => $post_id,
+		'type' => $item_type,
+		'amount' => $amount
+	);
+}
+
+/**
+ * Validate every cart line atomically.
+ */
+function ceo_paypal_ipn_validate_cart($item_names, $item_numbers, $comiceasel_config) {
+	if (!is_array($item_names) || !is_array($item_numbers) || empty($item_names) || count($item_names) !== count($item_numbers)) return false;
+
+	$validated = array();
+	$total = 0.0;
+	foreach ($item_names as $key => $item_name) {
+		if (!array_key_exists($key, $item_numbers)) return false;
+		$item = ceo_paypal_ipn_validate_item($item_numbers[$key], $item_name, $comiceasel_config);
+		if (!$item) return false;
+		$total += $item['amount'];
+		$validated[] = $item;
+	}
+	if (!is_finite($total) || $total <= 0) return false;
+	return array('items' => $validated, 'total' => $total);
+}
+
+function ceo_paypal_ipn_amount_covers($payment_amount, $expected_total) {
+	if (!is_numeric($payment_amount) || !is_finite((float)$payment_amount) || $expected_total <= 0) return false;
+	return ((float)$payment_amount + 0.001) >= $expected_total;
+}
+
 function ceo_paypal_ipn() {
+	$comiceasel_config = get_option('comiceasel-config');
+	// Reject unusable stores before making an outbound verification request. The endpoint is
+	// public even when the feature is not configured, so this also avoids needless remote
+	// requests from arbitrary visitors.
+	if (
+		ceo_paypal_merchant($comiceasel_config) === ''
+		|| ceo_paypal_currency($comiceasel_config) === ''
+		|| (empty($comiceasel_config['buy_comic_sell_print']) && empty($comiceasel_config['buy_comic_sell_original']))
+	) exit;
+
 	// template_redirect fires for every front-end request, so this endpoint is
 	// reachable by anyone. The payload is hostile until PayPal confirms it sent
 	// it -- nothing below may touch the database or send mail before that.
 	$ipn = array();
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- PayPal authenticates this webhook through ceo_paypal_ipn_verify().
 	foreach ($_POST as $key => $value) {
 		if (is_scalar($value)) $ipn[$key] = wp_unslash($value);
 	}
@@ -191,10 +290,11 @@ function ceo_paypal_ipn() {
 
 	// The cart size is attacker-supplied even on a verified notification, so
 	// clamp it rather than looping on whatever number arrived.
-	$num_cart_items = isset($ipn['num_cart_items']) ? (int)$ipn['num_cart_items'] : 1;
-	if ($num_cart_items < 1) $num_cart_items = 1;
-	$max_cart_items = apply_filters('ceo_paypal_max_cart_items', 100);
-	if ($num_cart_items > $max_cart_items) $num_cart_items = $max_cart_items;
+	$num_cart_items_raw = isset($ipn['num_cart_items']) ? trim((string)$ipn['num_cart_items']) : '1';
+	$max_cart_items = max(1, (int)apply_filters('ceo_paypal_max_cart_items', 100));
+	if (!ctype_digit($num_cart_items_raw)) exit;
+	$num_cart_items = (int)$num_cart_items_raw;
+	if ($num_cart_items < 1 || $num_cart_items > $max_cart_items) exit;
 
 	$count = 1;
 	$item_name = array();
@@ -221,74 +321,59 @@ function ceo_paypal_ipn() {
 	$address_zip = isset($ipn['address_zip']) ? $ipn['address_zip'] : '';
 	$address_country = isset($ipn['address_country']) ? $ipn['address_country'] : '';
 	$memo = isset($ipn['memo']) ? $ipn['memo'] : '';
+	if ($payment_status !== 'Completed' || trim((string)$txn_id) === '') exit;
 
 	// PayPal retries notifications until the endpoint acknowledges them, and a
 	// captured notification can be replayed by hand, so act on each transaction
 	// exactly once.
-	// Key on the transaction AND its status: PayPal sends a fresh notification when a
-	// payment moves Pending -> Completed, and keying on txn_id alone would discard the
-	// Completed one as a duplicate, so the sale would never be recorded.
+	// Keep the status suffix for compatibility with the existing replay ledger. Only
+	// Completed notifications reach this point, so a prior Pending notification cannot
+	// suppress the eventual sale.
 	$txn_key = $txn_id.'|'.$payment_status;
 	$processed_txn = get_option('ceo_paypal_processed_txn', array());
 	if (!is_array($processed_txn)) $processed_txn = array();
-	if ($txn_id !== '' && in_array($txn_key, $processed_txn, true)) exit;
+	if (in_array($txn_key, $processed_txn, true)) exit;
 
 	$email_message = '';
-	$comiceasel_config = get_option('comiceasel-config');
 
 	// A VERIFIED response only proves PayPal sent the notification. It says
 	// nothing about who was paid or how much, both of which travel to PayPal as
 	// hidden fields the buyer controls. Re-check them against the server side.
 	$payee_ok = ceo_paypal_ipn_payee_matches($ipn, $comiceasel_config);
 
-	$expected_total = 0;
-	for ($i = 1; $i <= $num_cart_items; $i++) {
-		$pid = (int)$item_number[$i];
-		if ($pid) $expected_total += ceo_paypal_ipn_expected_amount($pid, $item_name[$i]);
-	}
-	// mc_gross is a bare number, so comparing it to the asking price is only
-	// meaningful once the currency matches. The buy form sends no currency_code,
-	// which means PayPal settles these carts in the account's default -- but a
-	// hand-built cart naming notify_url can pick any currency, and 65 JPY would
-	// otherwise satisfy a $65 asking price.
-	// Comparing mc_gross without the currency lets a payment in a weaker unit satisfy the
-	// asking price numerically. There is nothing to compare against, though: the plugin has no
-	// currency setting, and the buy form does not send one, so PayPal bills these carts in the
-	// receiving account's own primary currency -- which is not USD for a seller outside the US.
-	// Hardcoding a default would reject every legitimate sale for those sellers.
-	//
-	// So pin to whatever this site is actually paid in: remember the currency from the first
-	// notification that carries one, and require later payments to match it. The first payment
-	// after upgrading goes unchecked, which is no worse than the behaviour it replaces, and
-	// every payment after that is covered without anyone having to configure anything.
-	$expected_currency = strtoupper((string)apply_filters('ceo_paypal_expected_currency', get_option('ceo_paypal_currency', '')));
-	$payment_currency_uc = strtoupper((string)$payment_currency);
-	$currency_ok = ($payment_currency_uc === '') || ($expected_currency === '') || ($payment_currency_uc === $expected_currency);
+	$validated_cart = ceo_paypal_ipn_validate_cart($item_name, $item_number, $comiceasel_config);
+	$cart_ok = ($validated_cart !== false);
+	$expected_total = $cart_ok ? $validated_cart['total'] : 0.0;
 
-	// mc_gross is the cart total and includes shipping, so it may legitimately
-	// exceed the asking price -- only underpayment is rejected. A site with no
-	// prices recorded has nothing to compare against and is not blocked.
-	$amount_ok = ($expected_total <= 0) || (((float)$payment_amount + 0.001) >= $expected_total);
+	$expected_currency = ceo_paypal_currency($comiceasel_config);
+	$payment_currency_uc = strtoupper(trim((string)$payment_currency));
+	$currency_ok = ($payment_currency_uc !== '' && $payment_currency_uc === $expected_currency);
+
+	// mc_gross includes shipping, so a total above the server-derived item prices is valid.
+	$amount_ok = $cart_ok && ceo_paypal_ipn_amount_covers($payment_amount, $expected_total);
 
 	if (!$payee_ok) $email_message .= __('REJECTED: payment was not made to the configured PayPal address.','comiceasel')."\r\n\r\n";
+	if (!$cart_ok) $email_message .= __('REJECTED: the cart does not match an available Comic Easel product.','comiceasel')."\r\n\r\n";
 	if (!$amount_ok) $email_message .= sprintf(__('REJECTED: amount paid (%1$s) is below the asking price (%2$s).','comiceasel'), $payment_amount, $expected_total)."\r\n\r\n";
-	if (!$currency_ok) $email_message .= sprintf(__('REJECTED: payment currency (%1$s) is not the %2$s this site is normally paid in.','comiceasel'), $payment_currency, $expected_currency)."\r\n\r\n";
+	if (!$currency_ok) $email_message .= sprintf(__('REJECTED: payment currency (%1$s) is not the configured currency (%2$s).','comiceasel'), $payment_currency, $expected_currency)."\r\n\r\n";
 
 	delete_option('ceo_paypal_receiver');
-	if ($payment_status == 'Completed' && $payee_ok && $amount_ok && $currency_ok) {
-		$count = 1;
-		foreach ($item_number as $item_sub_number) {
-			$post_id = (int)$item_number[$count];
-			if ($post_id && ceo_paypal_ipn_is_original($item_name[$count])) {
-				update_post_meta($post_id, 'buyorig-status', __('Sold','comiceasel'));
+	if ($payee_ok && $cart_ok && $amount_ok && $currency_ok) {
+		foreach ($validated_cart['items'] as $item) {
+			if ($item['type'] === 'original') {
+				update_post_meta($item['post_id'], 'buyorig-status', __('Sold','comiceasel'));
+				$post_id = $item['post_id'];
 				$email_message .= 'Comic ID #'.$post_id." Set to SOLD\r\n\r\n";
 				// Flush the cache on the item in question.
 				if (defined('WP_CACHE') && WP_CACHE == true && function_exists('wp_cache_no_postid')) {
 					wp_cache_no_postid($post_id);
 				}
 			}
-			$count++;
 		}
+		$processed_txn[] = $txn_key;
+		// Keep the ledger bounded; PayPal only retries for a few days.
+		if (count($processed_txn) > 500) $processed_txn = array_slice($processed_txn, -500);
+		update_option('ceo_paypal_processed_txn', $processed_txn, false);
 	}
 	$email_message .= __('Transaction URL','comiceasel').': '.home_url()."\r\n";
 	$email_message .= __('Number Items','comiceasel').': '.$num_cart_items."\r\n";
@@ -318,16 +403,6 @@ function ceo_paypal_ipn() {
 	/*		foreach ($_POST as $post_info) {
 				$email_message .= $post_info;
 			} */
-	// Remember the currency this site is paid in, so later payments can be checked against it.
-	if ($currency_ok && $payment_currency_uc !== '' && $expected_currency === '') {
-		update_option('ceo_paypal_currency', $payment_currency_uc, false);
-	}
-	if ($txn_id !== '') {
-		$processed_txn[] = $txn_key;
-		// Keep the ledger bounded; PayPal only retries for a few days.
-		if (count($processed_txn) > 500) $processed_txn = array_slice($processed_txn, -500);
-		update_option('ceo_paypal_processed_txn', $processed_txn, false);
-	}
 	update_option('ceo_paypal_receiver', $email_message);
 	if (isset($comiceasel_config['buy_comic_email']))
 		wp_mail($comiceasel_config['buy_comic_email'], __('Comic Easel: Notification of Transaction - Buy Comic','comiceasel'), $email_message);

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -500,6 +500,9 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 					'cancelled' => __('You have cancelled the transaction.','comiceasel')
 					), $atts ) );
 	$buy_output = '';
+	$paypal_config = ceo_pluginfo();
+	$paypal_currency = ceo_paypal_currency($paypal_config);
+	$paypal_ready = (ceo_paypal_merchant($paypal_config) !== '' && $paypal_currency !== '');
 	if (isset($_REQUEST['id'])) $comicnum = intval($_REQUEST['id']);
 	if (isset($_REQUEST['action'])) { 
 		$action = esc_attr($_REQUEST['action']);
@@ -552,8 +555,8 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 				$buy_output .= '<td align="left" valign="top" style="width:50%;">';
 				$buy_output .= '<div class="buycomic-us-form">';
 				$buy_output .= '<h4 class="buycomic-title">Print</h4>';
-				$buy_output .= '$'.esc_html($buy_print_amount).'<br />';
-				if ($buyprint_status == __('Available','comiceasel')) {
+				$buy_output .= esc_html($paypal_currency).' '.esc_html($buy_print_amount).'<br />';
+				if ($paypal_ready && $buyprint_status == __('Available','comiceasel')) {
 					$buy_output .= '<form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">';
 					$buy_output .= '<input type="hidden" name="add" value="1" />';
 					$buy_output .= '<input type="hidden" name="cmd" value="_cart" />';
@@ -563,6 +566,7 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 					$return_url = add_query_arg(array('action' => 'thankyou', 'id' => $comicnum), ceo_pluginfo('buy_comic_url'));
 					$buy_output .= '<input type="hidden" name="return" value="'.esc_url($return_url).'" />';
 					$buy_output .= '<input type="hidden" name="amount" value="'.esc_attr($buy_print_amount).'" />';
+					$buy_output .= '<input type="hidden" name="currency_code" value="'.esc_attr($paypal_currency).'" />';
 					$buy_output .= '<input type="hidden" name="item_number" value="'.esc_attr($comicnum).'" />';
 					$buy_output .= '<input type="hidden" name="business" value="'.esc_attr(ceo_pluginfo('buy_comic_email')).'" />';
 					$buy_output .= '<input type="image" src="'.esc_url(ceo_pluginfo('plugin_url').'images/buynow_paypal.png').'" name="submit32" alt="'.esc_attr(__('Make payments with PayPal - it is fast, free and secure!','comiceasel')).'" />';
@@ -583,8 +587,8 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 				$buy_output .= '<td align="left" valign="top" style="width:50%;">';
 				$buy_output .= '<div class="buycomic-us-form" style="width:100%;">';
 				$buy_output .= '<h4 class="buycomic-title">Original</h4>';
-				$buy_output .= '$'.esc_html($buy_print_orig_amount).'<br />';
-				if ($buyorig_status == __('Available','comiceasel')) {
+				$buy_output .= esc_html($paypal_currency).' '.esc_html($buy_print_orig_amount).'<br />';
+				if ($paypal_ready && $buyorig_status == __('Available','comiceasel')) {
 					$buy_output .= '<form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">';
 					$buy_output .= '<input type="hidden" name="add" value="1" />';
 					$buy_output .= '<input type="hidden" name="cmd" value="_cart" />';
@@ -594,6 +598,7 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 					$return_url = add_query_arg(array('action' => 'thankyou', 'id' => $comicnum), ceo_pluginfo('buy_comic_url'));
 					$buy_output .= '<input type="hidden" name="return" value="'.esc_url($return_url).'" />';
 					$buy_output .= '<input type="hidden" name="amount" value="'.esc_attr($buy_print_orig_amount).'" />';
+					$buy_output .= '<input type="hidden" name="currency_code" value="'.esc_attr($paypal_currency).'" />';
 					$buy_output .= '<input type="hidden" name="item_number" value="'.esc_attr($comicnum).'" />';
 					$buy_output .= '<input type="hidden" name="business" value="'.esc_attr(ceo_pluginfo('buy_comic_email')).'" />';
 					$buy_output .= '<input type="image" src="'.esc_url(ceo_pluginfo('plugin_url').'images/buynow_paypal.png').'" name="submit32" alt="'.esc_attr(__('Make payments with PayPal - it is fast, free and secure!','comiceasel')).'" />';

--- a/lang/comiceasel-en_US.po
+++ b/lang/comiceasel-en_US.po
@@ -2348,3 +2348,24 @@ msgstr ""
 #@ comic-easel
 msgid "Try to have Comic Easel automatically remove the featured image in posts on non-ComicPress themes?"
 msgstr ""
+
+#: options/buycomic.php:44
+#@ comic-easel
+msgid "PayPal currency code"
+msgstr ""
+
+#: options/buycomic.php:48
+#@ comic-easel
+msgid "The three-letter currency code used for prices and payments, for example USD, CAD, EUR, or GBP."
+msgstr ""
+
+#: functions/redirects.php:356
+#@ comic-easel
+msgid "REJECTED: the cart does not match an available Comic Easel product."
+msgstr ""
+
+#: functions/redirects.php:358
+#, php-format
+#@ comic-easel
+msgid "REJECTED: payment currency (%1$s) is not the configured currency (%2$s)."
+msgstr ""

--- a/options/buycomic.php
+++ b/options/buycomic.php
@@ -40,6 +40,15 @@
 					</td>
 				</tr>
 				<tr class="alternate">
+					<th scope="row" colspan="2">
+						<label for="buy_comic_currency"><?php esc_html_e('PayPal currency code','comiceasel'); ?></label>
+						<input type="text" size="3" maxlength="3" name="buy_comic_currency" id="buy_comic_currency" value="<?php echo esc_attr($ceo_options['buy_comic_currency']); ?>" />
+					</th>
+					<td>
+						<?php esc_html_e('The three-letter currency code used for prices and payments, for example USD, CAD, EUR, or GBP.','comiceasel'); ?>
+					</td>
+				</tr>
+				<tr>
 					<th scope="row"colspan="2">
 						<label for="buy_comic_url"><?php _e('FULL URL of where the buy comic shortcode is. (required)','comiceasel'); ?></label>
 						<input type="text" size="25" name="buy_comic_url" id="buy_comic_url" value="<?php echo esc_attr($ceo_options['buy_comic_url']); ?>" />
@@ -54,7 +63,7 @@
 						</em>
 					</td>
 				</tr>
-				<tr>
+				<tr class="alternate">
 					<th scope="row"><label for="buy_comic_sell_print"><?php _e('Are you selling prints?','comiceasel'); ?></label></th>
 					<td>
 						<input id="buy_comic_sell_print" name="buy_comic_sell_print" type="checkbox" value="1" <?php checked(true, $ceo_options['buy_comic_sell_print']); ?> />
@@ -63,7 +72,7 @@
 						<?php _e('<strong>NOTE: If you want to add shipping you will have to do that from your profile on paypal.</strong>','comiceasel'); ?>
 					</td>
 				</tr>
-				<tr class="alternate">
+				<tr>
 					<th scope="row"><label for="buy_comic_print_amount"><?php _e('Print Cost','comiceasel'); ?></label></th>
 					<td>
 						<input type="text" size="7" name="buy_comic_print_amount" id="buy_comic_print_amount" value="<?php echo esc_attr($ceo_options['buy_comic_print_amount']); ?>" />
@@ -72,7 +81,7 @@
 						<?php _e('How much does a print cost?','comiceasel'); ?>
 					</td>
 				</tr>
-				<tr>
+				<tr class="alternate">
 					<th scope="row"><label for="buy_comic_sell_original"><?php _e('Are you selling the original?','comiceasel'); ?></label></th>
 					<td>
 						<input id="buy_comic_sell_original" name="buy_comic_sell_original" type="checkbox" value="1" <?php checked(true, $ceo_options['buy_comic_sell_original']); ?> />
@@ -81,7 +90,7 @@
 						<?php _e('<strong>NOTE: If you want to add shipping you will have to do that from your profile on paypal.</strong>','comiceasel'); ?>
 					</td>
 				</tr>
-				<tr class="alternate">
+				<tr>
 					<th scope="row"><label for="buy_comic_orig_amount"><?php _e('Original Cost','comiceasel'); ?></label></th>
 					<td>
 						<input type="text" size="7" name="buy_comic_orig_amount" id="buy_comic_orig_amount" value="<?php echo esc_attr($ceo_options['buy_comic_orig_amount']); ?>" />

--- a/tests/CE_TestCase.php
+++ b/tests/CE_TestCase.php
@@ -54,6 +54,16 @@ abstract class CE_TestCase extends TestCase {
 		CE_Test_State::$post_meta[ $post_id . ':' . $key ] = $value;
 	}
 
+	protected function setPost( $id, $type = 'comic', $status = 'publish', $password = '' ) {
+		$post                = new stdClass();
+		$post->ID            = $id;
+		$post->post_type     = $type;
+		$post->post_status   = $status;
+		$post->post_password = $password;
+		CE_Test_State::$posts[ $id ] = $post;
+		return $post;
+	}
+
 	protected function grantCap( $user_id, $cap ) {
 		CE_Test_State::$user_caps[ $user_id . ':' . $cap ] = true;
 	}

--- a/tests/PaypalIpnTest.php
+++ b/tests/PaypalIpnTest.php
@@ -125,6 +125,12 @@ class PaypalIpnTest extends CE_TestCase {
 		);
 	}
 
+	public function testUnknownItemLabelsAreNotTreatedAsPrints() {
+		CE_Test_State::$pluginfo['buy_comic_print_amount'] = '25.00';
+		$this->assertFalse( ceo_paypal_ipn_item_type( 'Poster - My Comic - 7' ) );
+		$this->assertSame( 0.0, ceo_paypal_ipn_expected_amount( 7, 'Poster - My Comic - 7' ) );
+	}
+
 	/**
 	 * The item name is built when the form renders, but __() here resolves when the
 	 * notification arrives. Both labels must work, or changing the site language silently
@@ -196,14 +202,9 @@ class PaypalIpnTest extends CE_TestCase {
 		$this->assertFalse( ceo_paypal_ipn_payee_matches( array(), $config ) );
 	}
 
-	/**
-	 * The checks fail open where there is nothing to compare against, so a half-configured
-	 * shop is not broken by this. That is a deliberate trade-off and worth pinning, because
-	 * it means these sites accept a payment made to anybody.
-	 */
 	#[DataProvider( 'unconfiguredPayeeProvider' )]
-	public function testPayeeCheckFailsOpenWhenNothingIsConfigured( $config ) {
-		$this->assertTrue( ceo_paypal_ipn_payee_matches( array( 'receiver_email' => 'anyone@evil.test' ), $config ) );
+	public function testPayeeCheckFailsClosedWhenNothingIsConfigured( $config ) {
+		$this->assertFalse( ceo_paypal_ipn_payee_matches( array( 'receiver_email' => 'anyone@evil.test' ), $config ) );
 	}
 
 	public static function unconfiguredPayeeProvider() {
@@ -214,5 +215,108 @@ class PaypalIpnTest extends CE_TestCase {
 			'shipped placeholder'    => array( array( 'buy_comic_email' => 'yourname@yourpaypalemail.com' ) ),
 			'placeholder, odd case'  => array( array( 'buy_comic_email' => 'YourName@YourPayPalEmail.com' ) ),
 		);
+	}
+
+	/* ---------------------------------------------------------------- *
+	 * Full server-side cart validation
+	 * ---------------------------------------------------------------- */
+
+	private function validStoreConfig() {
+		return array(
+			'buy_comic_email'         => 'merchant@example.com',
+			'buy_comic_currency'      => 'USD',
+			'buy_comic_sell_print'    => true,
+			'buy_comic_sell_original' => true,
+		);
+	}
+
+	public function testCurrencyMustBeExplicitAndThreeLetters() {
+		$this->assertSame( '', ceo_paypal_currency( array() ) );
+		$this->assertSame( '', ceo_paypal_currency( array( 'buy_comic_currency' => 'US' ) ) );
+		$this->assertSame( 'CAD', ceo_paypal_currency( array( 'buy_comic_currency' => ' cad ' ) ) );
+
+		CE_Test_State::$filters['ceo_paypal_expected_currency'] = 'EUR';
+		$this->assertSame( 'EUR', ceo_paypal_currency( array( 'buy_comic_currency' => 'USD' ) ) );
+	}
+
+	public function testAValidPublishedAvailableComicIsAccepted() {
+		$this->setPost( 7 );
+		$this->setPostMeta( 7, 'buy_print_orig_amount', '65.00' );
+
+		$item = ceo_paypal_ipn_validate_item( 7, 'Original - My Comic - 7', $this->validStoreConfig() );
+
+		$this->assertSame(
+			array( 'post_id' => 7, 'type' => 'original', 'amount' => 65.0 ),
+			$item
+		);
+	}
+
+	#[DataProvider( 'invalidPostProvider' )]
+	public function testOnlyPublicUnprotectedComicsAreAccepted( $type, $status, $password ) {
+		$this->setPost( 7, $type, $status, $password );
+		$this->setPostMeta( 7, 'buy_print_orig_amount', '65.00' );
+
+		$this->assertFalse(
+			ceo_paypal_ipn_validate_item( 7, 'Original - My Comic - 7', $this->validStoreConfig() )
+		);
+	}
+
+	public static function invalidPostProvider() {
+		return array(
+			'ordinary post'       => array( 'post', 'publish', '' ),
+			'draft comic'         => array( 'comic', 'draft', '' ),
+			'private comic'       => array( 'comic', 'private', '' ),
+			'password protected'  => array( 'comic', 'publish', 'secret' ),
+		);
+	}
+
+	public function testDisabledSoldUnknownAndZeroPricedProductsAreRejected() {
+		$this->setPost( 7 );
+		$this->setPostMeta( 7, 'buy_print_orig_amount', '65.00' );
+		$config = $this->validStoreConfig();
+
+		$config['buy_comic_sell_original'] = false;
+		$this->assertFalse( ceo_paypal_ipn_validate_item( 7, 'Original - x - 7', $config ) );
+
+		$config['buy_comic_sell_original'] = true;
+		$this->setPostMeta( 7, 'buyorig-status', 'Sold' );
+		$this->assertFalse( ceo_paypal_ipn_validate_item( 7, 'Original - x - 7', $config ) );
+
+		$this->setPostMeta( 7, 'buyorig-status', '' );
+		$this->assertFalse( ceo_paypal_ipn_validate_item( 7, 'Poster - x - 7', $config ) );
+
+		$this->setPostMeta( 7, 'buy_print_orig_amount', 'not a price' );
+		$this->assertFalse( ceo_paypal_ipn_validate_item( 7, 'Original - x - 7', $config ) );
+	}
+
+	public function testOneBadLineRejectsTheEntireCart() {
+		$this->setPost( 7 );
+		$this->setPostMeta( 7, 'buy_print_orig_amount', '65.00' );
+
+		$this->assertFalse(
+			ceo_paypal_ipn_validate_cart(
+				array( 1 => 'Original - Good - 7', 2 => 'Original - Missing - 8' ),
+				array( 1 => 7, 2 => 8 ),
+				$this->validStoreConfig()
+			)
+		);
+	}
+
+	public function testCartTotalsAndAmountChecksUseServerPrices() {
+		$this->setPost( 7 );
+		$this->setPost( 8 );
+		$this->setPostMeta( 7, 'buy_print_orig_amount', '65.00' );
+		$this->setPostMeta( 8, 'buy_print_amount', '25.00' );
+
+		$cart = ceo_paypal_ipn_validate_cart(
+			array( 1 => 'Original - One - 7', 2 => 'Print - Two - 8' ),
+			array( 1 => 7, 2 => 8 ),
+			$this->validStoreConfig()
+		);
+
+		$this->assertSame( 90.0, $cart['total'] );
+		$this->assertFalse( ceo_paypal_ipn_amount_covers( '89.99', $cart['total'] ) );
+		$this->assertTrue( ceo_paypal_ipn_amount_covers( '95.00', $cart['total'] ) );
+		$this->assertFalse( ceo_paypal_ipn_amount_covers( '95 dollars', $cart['total'] ) );
 	}
 }

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -107,8 +107,11 @@ add_filter( 'pre_wp_mail', function ( $null, $atts ) {
 }, 10, 2 );
 ```
 
-`ceo_paypal_expected_currency` (default `USD`) and `ceo_paypal_max_cart_items` are filterable
-too.
+Set the three-letter PayPal currency on Comic Easel's Buy Comic settings tab. Existing stores
+must choose and save it once after upgrading; checkout stays hidden until both the merchant
+address and currency are configured. `ceo_paypal_expected_currency` can override that setting
+for integrations that hide the built-in tab, and the same resolved value is used by checkout
+and IPN validation. `ceo_paypal_max_cart_items` is filterable too.
 
 Then POST to `/?ceopaypalipn` directly. The reject paths matter as much as the accept path,
 because each should say *why* in the notification email rather than silently doing nothing:
@@ -116,15 +119,15 @@ because each should say *why* in the notification email rather than silently doi
 | Case | Expected |
 |---|---|
 | stub answers anything but `VERIFIED` | nothing written, no mail |
-| valid: right payee, currency and amount | comic marked Sold, owner emailed |
+| valid: right payee, configured currency and amount | comic marked Sold, owner emailed |
 | `business` is not the configured address | not sold, "REJECTED: payment was not made to the configured PayPal address." |
-| `mc_currency` is not the expected currency | not sold, "REJECTED: payment currency ... is not USD." |
+| `mc_currency` is not the configured currency | not sold, "REJECTED: payment currency ... is not the configured currency ..." |
 | `mc_gross` below the asking price | not sold, "REJECTED: amount paid ... is below the asking price" |
 | same `txn_id` and status replayed | ignored, no second mail |
-| `Pending` then `Completed`, same `txn_id` | both processed; the `Completed` one marks it Sold |
+| `Pending` then `Completed`, same `txn_id` | Pending ignored; Completed marks it Sold |
 
-That last row is worth keeping: the ledger is keyed on transaction *and* status precisely so a
-Pending notification cannot swallow the Completed one that follows it.
+That last row is worth keeping: ignored statuses never enter the replay ledger, so a Pending
+notification cannot swallow the Completed one that follows it.
 
 ## Always
 

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -26,6 +26,8 @@ class CE_Test_State {
 	public static $options = array();
 	/** @var array<string,mixed> "postid:metakey" => value */
 	public static $post_meta = array();
+	/** @var array<int,object> post ID => lightweight WP_Post stand-in */
+	public static $posts = array();
 	/** @var array<string,bool> "userid:cap" => bool */
 	public static $user_caps = array();
 	/** @var array<string,mixed> filter tag => value to return */
@@ -48,6 +50,7 @@ class CE_Test_State {
 	public static function reset() {
 		self::$options = array( 'blog_charset' => 'UTF-8' );
 		self::$post_meta = array();
+		self::$posts = array();
 		self::$user_caps = array();
 		self::$filters = array();
 		self::$translations = array();
@@ -369,6 +372,13 @@ if ( ! function_exists( 'shortcode_atts' ) ) {
 if ( ! function_exists( 'get_posts' ) ) {
 	function get_posts( $args = array() ) {
 		return array();
+	}
+}
+
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $post = null ) {
+		$post_id = is_object( $post ) && isset( $post->ID ) ? (int) $post->ID : (int) $post;
+		return array_key_exists( $post_id, CE_Test_State::$posts ) ? CE_Test_State::$posts[ $post_id ] : null;
 	}
 }
 


### PR DESCRIPTION
## Summary

- require PayPal `VERIFIED` and `Completed` notifications with a transaction ID
- validate the merchant, configured currency, complete cart, and server-side prices before changing comic metadata
- reject mixed or replayed carts atomically and add focused IPN regression coverage

## Important upgrade note for BuyComic users

**Existing BuyComic stores must open Comic Easel → Config → Buy Comic, choose their three-letter PayPal currency code, and save once after updating.** Checkout remains hidden and IPN processing remains disabled until both the merchant address and currency are configured. New installations default to USD.

The checkout form now sends that explicit currency, and IPN validation requires it to match. Integrations that hide the built-in settings tab can continue to supply it through `ceo_paypal_expected_currency`.

## Testing

- PHPUnit: 151 tests, 210 assertions
- PHP syntax checks and changed-line PHPCS
- no live PayPal sandbox transaction was performed

Co-authored by gpt-5.6-sol.
