### PR TITLE
Escape remaining public output contexts

### DIFF
--- a/functions/displaycomic.php
+++ b/functions/displaycomic.php
@@ -15,7 +15,8 @@ function ceo_display_featured_image_comic($size = 'full') {
 		if (!empty($hovertext)) {
 			$hovertext = 'alt="'.$hovertext.'" title="'.$hovertext.'" ';
 		} else {
-			$hovertext = 'alt="'.get_the_title($post->ID).'" title="'.get_the_title($post->ID).'" ';
+			$title = ceo_title_for_attribute($post->ID);
+			$hovertext = 'alt="'.$title.'" title="'.$title.'" ';
 		}
 		$thumbnail = wp_get_attachment_image_src( $post_image_id, $size, false);
 		if (is_array($thumbnail)) {
@@ -41,16 +42,16 @@ function ceo_display_featured_image_comic($size = 'full') {
 			if ($linkto && !$comic_has_map) $output .= '<a href="'.esc_url($linkto).'" '.$hovertext.'>';
 			
 			if ($comic_lightbox && !$linkto && !$comic_has_map) {
-				$output .= '<a href="'.$thumbnail.'" '.$hovertext.' rel="lightbox">';
+				$output .= '<a href="'.esc_url($thumbnail).'" '.$hovertext.' rel="lightbox">';
 			}
-			
+
 			if (ceo_pluginfo('click_comic_next') && !empty($next_comic) && !$comic_lightbox && !$linkto && !$comic_has_map) {
-				$output .= '<a href="'.$next_comic.'" '.$hovertext.'>';
+				$output .= '<a href="'.esc_url($next_comic).'" '.$hovertext.'>';
 			}
 			// only show if the comic is not linkable
 			if ($comic_has_map) $usemap = 'usemap="#comicmap" ';
 			
-			$output .= '<img src="'.$thumbnail.'" '.$hovertext.' '.$usemap.' />';
+			$output .= '<img src="'.esc_url($thumbnail).'" '.$hovertext.' '.$usemap.' />';
 			if ((ceo_pluginfo('click_comic_next') && !empty($next_comic) && !$comic_has_map) || $comic_lightbox || $linkto) {
 				$output .= '</a>';
 			}
@@ -94,12 +95,12 @@ function ceo_display_comic_gallery($size = 'full') {
 //				$thumbnail = apply_filters('jetpack_photon_url', $thumbnail);
 
 				if ($comic_lightbox) {
-					$output .= '<a href="'.$thumbnail.'" title="'.$hovertext.'" rel="lightbox">';
+					$output .= '<a href="'.esc_url($thumbnail).'" title="'.$hovertext.'" rel="lightbox">';
 				}
 				if (ceo_pluginfo('click_comic_next') && !empty($next_comic) && !$comic_lightbox) {
-					$output .= '<a href="'.$next_comic.'" title="'.$hovertext.'">';
+					$output .= '<a href="'.esc_url($next_comic).'" title="'.$hovertext.'">';
 				}
-				$output .= '<img src="'.$thumbnail.'" alt="'.$hovertext.'" title="'.$hovertext.'" />';
+				$output .= '<img src="'.esc_url($thumbnail).'" alt="'.$hovertext.'" title="'.$hovertext.'" />';
 				if ((ceo_pluginfo('click_comic_next') && !empty($next_comic)) || $comic_lightbox) {
 					$output .= '</a>';
 				}
@@ -271,7 +272,7 @@ function ceo_display_comic_thumbnail($thumbnail_size = 'thumbnail', $override_po
 			$thumbnail = get_the_post_thumbnail($post_to_use->ID, $thumbnail_size);
 	}
 	if ( has_post_thumbnail($post_to_use->ID) ) {
-		$output =  '<a href="'.get_permalink($post_to_use->ID).'" rel="bookmark" title="'.get_the_title().'">'.$thumbnail.'</a>'."\r\n";
+		$output =  '<a href="'.esc_url(get_permalink($post_to_use->ID)).'" rel="bookmark" title="'.ceo_title_for_attribute($post_to_use->ID).'">'.$thumbnail.'</a>'."\r\n";
 	} else {
 //			$output = "No Thumbnail Found.";
 	}

--- a/functions/filters.php
+++ b/functions/filters.php
@@ -66,7 +66,7 @@ function ceo_change_prev_rel_link_two($link) {
 	if ($post->post_type=='comic' || is_home() || is_front_page()) {
 		$link_url = ceo_get_previous_comic_permalink();
 		if (!empty($link_url)) {
-			$link='<link rel="prev" href="'.$link_url.'" />'."\r\n";
+			$link='<link rel="prev" href="'.esc_url($link_url).'" />'."\r\n";
 		}
 	}
 	return $link;
@@ -77,7 +77,7 @@ function ceo_change_next_rel_link_two($link) {
 	if ($post->post_type=='comic' || is_home() || is_front_page()) {
 		$link_url = ceo_get_next_comic_permalink();
 		if (!empty($link_url)) {
-			$link='<link rel="next" href="'.$link_url.'" />'."\r\n";
+			$link='<link rel="next" href="'.esc_url($link_url).'" />'."\r\n";
 		}
 	}
 	return $link;

--- a/functions/injections.php
+++ b/functions/injections.php
@@ -121,8 +121,8 @@ function ceo_display_comic_navigation() {
 	?>
 	<table id="comic-nav-wrapper">
 		<tr class="comic-nav-container">
-			<td class="comic-nav"><?php if ( get_permalink() != $first_comic ) { ?><a href="<?php echo $first_comic ?>" class="comic-nav-base comic-nav-first<?php if ( get_permalink() == $first_comic ) { ?> comic-nav-inactive<?php } ?>"><?php echo $first_text; ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-first comic-nav-void">'.$first_text.'</span>'; } ?></td>
-			<td class="comic-nav"><?php if ($prev_comic) { ?><a href="<?php echo $prev_comic ?>" class="comic-nav-base comic-nav-previous<?php if (!$prev_comic) { ?> comic-nav-inactive<?php } ?>"><?php echo $prev_text; ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-previous comic-nav-void ">'.$prev_text.'</span>'; } ?></td>
+			<td class="comic-nav"><?php if ( get_permalink() != $first_comic ) { ?><a href="<?php echo esc_url($first_comic); ?>" class="comic-nav-base comic-nav-first<?php if ( get_permalink() == $first_comic ) { ?> comic-nav-inactive<?php } ?>"><?php echo esc_html($first_text); ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-first comic-nav-void">'.esc_html($first_text).'</span>'; } ?></td>
+			<td class="comic-nav"><?php if ($prev_comic) { ?><a href="<?php echo esc_url($prev_comic); ?>" class="comic-nav-base comic-nav-previous<?php if (!$prev_comic) { ?> comic-nav-inactive<?php } ?>"><?php echo esc_html($prev_text); ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-previous comic-nav-void ">'.esc_html($prev_text).'</span>'; } ?></td>
 <?php
 		if (ceo_pluginfo('enable_buy_comic') && !wp_is_mobile()) {
 			if (strpos(ceo_pluginfo('buy_comic_url'), '?') !== false) {
@@ -135,7 +135,7 @@ function ceo_display_comic_navigation() {
 <?php }
 if (ceo_pluginfo('enable_comment_nav') && !wp_is_mobile()) { 
 			$commentscount = get_comments_number(); ?>
-			<td class="comic-nav"><a href="<?php comments_link(); ?>" class="comic-nav-comments" title="<?php the_title(); ?>"><span class="comic-nav-comment-count"><?php echo sprintf( _n( 'Comment(%d)', 'Comments(%d)', $commentscount, 'comiceasel' ), $commentscount ); ?></span></a></td>
+			<td class="comic-nav"><a href="<?php comments_link(); ?>" class="comic-nav-comments" title="<?php echo ceo_title_for_attribute($post->ID); ?>"><span class="comic-nav-comment-count"><?php echo esc_html(sprintf( _n( 'Comment(%d)', 'Comments(%d)', $commentscount, 'comiceasel' ), $commentscount )); ?></span></a></td>
 <?php } 
 	if (ceo_pluginfo('enable_random_nav') && !wp_is_mobile()) { 
 		$stay = '';
@@ -144,10 +144,10 @@ if (ceo_pluginfo('enable_comment_nav') && !wp_is_mobile()) {
 			if (!empty($chapter) && !is_wp_error($chapter)) $stay = '&stay='.reset($chapter)->term_id;
 		}
 ?>
-			<td class="comic-nav"><a href="<?php bloginfo('url') ?>?random&nocache=1<?php echo $stay; ?>" class="comic-nav-random" title="Random Comic"><?php _e('Random','comiceasel'); ?></a></td>
+			<td class="comic-nav"><a href="<?php bloginfo('url') ?>?random&nocache=1<?php echo esc_attr($stay); ?>" class="comic-nav-random" title="Random Comic"><?php esc_html_e('Random','comiceasel'); ?></a></td>
 <?php } ?>
-	<td class="comic-nav"><?php if ($next_comic) { ?><a href="<?php echo $next_comic ?>" class="comic-nav-base comic-nav-next<?php if (!$next_comic) { ?> comic-nav-inactive<?php } ?>"><?php echo $next_text; ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-next comic-nav-void ">'.$next_text.'</span>'; } ?></td>
-	<td class="comic-nav"><?php if ( get_permalink() != $last_comic ) { ?><a href="<?php echo $last_comic ?>" class="comic-nav-base comic-nav-last<?php if ( get_permalink() == $last_comic ) { ?> comic-nav-inactive<?php } ?>"><?php echo $last_text; ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-last comic-nav-void ">'.$last_text.'</span>'; } ?></td>
+	<td class="comic-nav"><?php if ($next_comic) { ?><a href="<?php echo esc_url($next_comic); ?>" class="comic-nav-base comic-nav-next<?php if (!$next_comic) { ?> comic-nav-inactive<?php } ?>"><?php echo esc_html($next_text); ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-next comic-nav-void ">'.esc_html($next_text).'</span>'; } ?></td>
+	<td class="comic-nav"><?php if ( get_permalink() != $last_comic ) { ?><a href="<?php echo esc_url($last_comic); ?>" class="comic-nav-base comic-nav-last<?php if ( get_permalink() == $last_comic ) { ?> comic-nav-inactive<?php } ?>"><?php echo esc_html($last_text); ?></a><?php } else { echo '<span class="comic-nav-base comic-nav-last comic-nav-void">'.esc_html($last_text).'</span>'; } ?></td>
 <?php if (ceo_pluginfo('enable_chapter_nav')) { ?>				
 			<td class="comic-nav comic-nav-jumpto"><?php ceo_comic_archive_jump_to_chapter(true, '', false, ceo_pluginfo('default_nav_bar_chapter_goes_to_archive')); ?></td>
 <?php } 
@@ -163,7 +163,7 @@ if (ceo_pluginfo('enable_comment_nav') && !wp_is_mobile()) {
 					$thumbnail = wp_get_attachment_image_src( $post_image_id, 'full', false);
 					if (is_array($thumbnail)) { 
 						$thumbnail = reset($thumbnail);
-						echo $thumbnail;
+						echo esc_html($thumbnail);
 					}
 				?>
 			</td>
@@ -178,7 +178,7 @@ if (!function_exists('ceo_display_comic_wrapper')) {
 	function ceo_display_comic_wrapper() {
 		global $post;
 		if ($post->post_type == 'comic') { ?>
-			<div id="comic-wrap" class="comic-id-<?php echo $post->ID; ?>">
+			<div id="comic-wrap" class="comic-id-<?php echo (int)$post->ID; ?>">
 				<div id="comic-head">
 					<?php if (!ceo_pluginfo('disable_default_nav') && ceo_pluginfo('enable_nav_above_comic')) ceo_display_comic_navigation(); ?>
 				</div>
@@ -343,7 +343,7 @@ global $post, $wp_query; ?>
 		<div class="comic-post-head"></div>
 		<div class="comic-post-content">
 			<div class="comic-post-text post-title">
-				<h2 class="comic-post-title entry-title"><a href="<?php echo get_permalink(); ?>"><?php the_title(); ?></a></h2>
+				<h2 class="comic-post-title entry-title"><a href="<?php echo esc_url(get_permalink()); ?>"><?php echo ceo_title_for_html($post->ID); ?></a></h2>
 			</div>
 			<div class="comic-post-info">
 				<?php do_action('comic-post-info'); ?>
@@ -417,7 +417,8 @@ global $post, $wp_query, $wpdb, $table_prefix;
 					$output .= '<ul class="related-ul">'."\r\n";
 					foreach ($related as $post_info) {
 //						if (has_post_thumbnail($post_info->ID)) the_post_thumbnail($post_info->ID);
-						$output .= 	'<li class="related-comic"><a title="'.wptexturize($post_info->post_title).'" href="'.get_permalink($post_info->ID).'">'.wptexturize($post_info->post_title).'</a></li>'."\r\n";
+						$texturized_title = wptexturize($post_info->post_title);
+						$output .= 	'<li class="related-comic"><a title="'.esc_attr($texturized_title).'" href="'.esc_url(get_permalink($post_info->ID)).'">'.wp_kses_post($texturized_title).'</a></li>'."\r\n";
 					}
 					$output .= "</ul>\r\n";
 					$output .= "</div>\r\n";
@@ -445,7 +446,7 @@ function ceo_social_meta() {
 		$thumbnail = wp_get_attachment_image_src( $post_image_id, ceo_pluginfo('thumbnail_size_for_facebook'), false);
 		if (is_array($thumbnail)) { 
 			$thumbnail = reset($thumbnail);
-			echo '<meta property="og:image" content="'.$thumbnail.'" />'."\r\n";
+			echo '<meta property="og:image" content="'.esc_url($thumbnail).'" />'."\r\n";
 //			echo '<meta name="twitter:image" content="'.$thumbnail.'" />'."\r\n";
 		}		
 	}

--- a/functions/library.php
+++ b/functions/library.php
@@ -1,6 +1,23 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
+/**
+ * A post title prepared for an HTML attribute.
+ */
+function ceo_title_for_attribute($post = 0) {
+	return esc_attr(get_the_title($post));
+}
+
+/**
+ * A post title prepared for normal HTML content.
+ *
+ * Titles are filterable, and some existing sites add harmless inline markup. KSES preserves
+ * that markup while removing scripts and event handlers.
+ */
+function ceo_title_for_html($post = 0) {
+	return wp_kses_post(get_the_title($post));
+}
+
 /*
 *  Get a sidebar and create a generic dynamic sidebar for it, else find the sidebar-*.php in the theme/childtheme
 */

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -17,13 +17,13 @@ function ceo_cast_display($character, $stats, $image) {
 		$cast_output .= '<tr>';
 		if ($image) {
 			$cast_output .= '<td class="cast-image">';
-			$cast_output .= '<div class="cast-pic character-'.$character->slug.'">';
+			$cast_output .= '<div class="'.esc_attr('cast-pic character-'.$character->slug).'">';
 			$cast_output .= '</div></td>';
 		}
-		$cast_output .= '<td class="cast-info cast-info-'.$character->slug.'">';
-		$cast_output .= '<h4 class="cast-name"><a href="'.get_term_link($character->slug, 'characters').'">'.$character->name.'</a></h4>';
+		$cast_output .= '<td class="'.esc_attr('cast-info cast-info-'.$character->slug).'">';
+		$cast_output .= '<h4 class="cast-name"><a href="'.esc_url(get_term_link($character->slug, 'characters')).'">'.wp_kses_post($character->name).'</a></h4>';
 		$cast_output .= '<p class="cast-description">';
-		$cast_output .= $character->description;
+		$cast_output .= wp_kses_post($character->description);
 		$cast_output .= '</p>';
 		if ($stats) {
 			$cast_output .= '<p class="cast-character-stats">';
@@ -47,10 +47,10 @@ function ceo_cast_display($character, $stats, $image) {
 				$last_seen_title = $last_seen_object->post_title;
 				$last_seen_id = $last_seen_object->ID;
 				if ($first_seen_id == $last_seen_id) {
-					$cast_output .= '<i>'.__('Only Appearance:','comiceasel').'</i> <a href="'.get_permalink($first_seen_id).'">'.$first_seen_title.'</a><br />';
+					$cast_output .= '<i>'.__('Only Appearance:','comiceasel').'</i> <a href="'.esc_url(get_permalink($first_seen_id)).'">'.wp_kses_post($first_seen_title).'</a><br />';
 				} else {
-					$cast_output .= '<i>'.__('Recent Appearance:','comiceasel').'</i> <a href="'.get_permalink($last_seen_id).'">'.$last_seen_title.'</a><br />';
-					$cast_output .= '<i>'.__('First Appearance:','comiceasel').'</i> <a href="'.get_permalink($first_seen_id).'">'.$first_seen_title.'</a><br />';			
+					$cast_output .= '<i>'.__('Recent Appearance:','comiceasel').'</i> <a href="'.esc_url(get_permalink($last_seen_id)).'">'.wp_kses_post($last_seen_title).'</a><br />';
+					$cast_output .= '<i>'.__('First Appearance:','comiceasel').'</i> <a href="'.esc_url(get_permalink($first_seen_id)).'">'.wp_kses_post($first_seen_title).'</a><br />';
 				}
 			}
 			$qposts = null;
@@ -127,7 +127,7 @@ function ceo_cast_page( $atts, $content = '' ) {
 			$cast_output .= ceo_cast_display($single_character, $stats, $image)."\r\n";
 			$cast_output .= '</table>'."\r\n";
 		} else 
-			$cast_output .= __('Unknown Character:', 'comiceasel').'&nbsp;'.$character."<br />\r\n";
+			$cast_output .= __('Unknown Character:', 'comiceasel').'&nbsp;'.esc_html($character)."<br />\r\n";
 	}
 	return $cast_output;
 }
@@ -173,9 +173,9 @@ function ceo_archive_list_single($chapter = 0, $order = 'ASC', $thumbnail = 0) {
 	$single_chapter = get_term_by('term_id', $chapter, 'chapters');
 	if (is_null($single_chapter)) { echo "Invalid Chapter Specified"; return; }
 	$output .= '<div class="comic-archive-chapter-wrap">';
-	$output .= '<h3 class="comic-archive-chapter">'.$single_chapter->name.'</h3>';
-	$output .= '<div class="comic-archive-image-'.$single_chapter->slug.'"></div>';
-	$output .= '<div class="comic-archive-chapter-description">'.$single_chapter->description.'</div>';
+	$output .= '<h3 class="comic-archive-chapter">'.wp_kses_post($single_chapter->name).'</h3>';
+	$output .= '<div class="'.esc_attr('comic-archive-image-'.$single_chapter->slug).'"></div>';
+	$output .= '<div class="comic-archive-chapter-description">'.wp_kses_post($single_chapter->description).'</div>';
 	$args = array(
 			'numberposts' => -1,
 			'post_type' => 'comic',
@@ -194,7 +194,7 @@ function ceo_archive_list_single($chapter = 0, $order = 'ASC', $thumbnail = 0) {
 	foreach ($qposts as $qpost) {
 		$archive_count++;
 		if ($css_alt) { $alternate = ' comic-list-alt'; $css_alt = false; } else { $alternate = ''; $css_alt=true; }		
-		$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qpost->ID).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qpost->post_title).'">'.esc_html($qpost->post_title).'</a></span></div>';
+		$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.esc_url(get_permalink($qpost->ID)).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qpost->post_title).'">'.esc_html($qpost->post_title).'</a></span></div>';
 	}
 	$output .= '</div>';
 	$output .= '<div style="clear:both;"></div></div>';
@@ -220,9 +220,9 @@ function ceo_archive_list_all($order = 'ASC', $thumbnail = 0) {
 	foreach ($all_chapters as $chapter) {
 		if ($chapter->count) {
 			$output .= '<div class="comic-archive-chapter-wrap">'."\r\n";
-			$output .= '<h3 class="comic-archive-chapter">'.$chapter->name.'</h3>'."\r\n";
-			$output .= '<div class="comic-archive-image-'.$chapter->slug.'"></div>'."\r\n";
-			$output .= '<div class="comic-archive-chapter-description">'.$chapter->description.'</div>'."\r\n";			
+			$output .= '<h3 class="comic-archive-chapter">'.wp_kses_post($chapter->name).'</h3>'."\r\n";
+			$output .= '<div class="'.esc_attr('comic-archive-image-'.$chapter->slug).'"></div>'."\r\n";
+			$output .= '<div class="comic-archive-chapter-description">'.wp_kses_post($chapter->description).'</div>'."\r\n";
 			$args = array(
 					'numberposts' => -1,
 					'post_type' => 'comic',
@@ -242,7 +242,7 @@ function ceo_archive_list_all($order = 'ASC', $thumbnail = 0) {
 			foreach ($qposts as $qpost) {
 				$archive_count++;
 				if ($css_alt) { $alternate = ' comic-list-alt'; $css_alt = false; } else { $alternate = ''; $css_alt=true; }
-				$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qpost->ID).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qpost->post_title).'">'.esc_html($qpost->post_title).'</a></span></div>'."\r\n";
+				$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qpost->ID).'</span><span class="comic-archive-title"><a href="'.esc_url(get_permalink($qpost->ID)).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qpost->post_title).'">'.esc_html($qpost->post_title).'</a></span></div>'."\r\n";
 			}
 			$output .= '</div>'."\r\n";
 			$output .= '<div style="clear:both;"></div></div>'."\r\n";
@@ -265,17 +265,17 @@ function ceo_archive_list_series($thumbnail = 0) {
 	$parent_chapters = get_terms('chapters', $args);
 	if (is_array($parent_chapters)) {
 		foreach($parent_chapters as $parent_chapter) {
-			$output .= '<h2 class="comic-archive-series-title">'.$parent_chapter->name.'</h2>';
-			$output .= '<div class="comic-archive-image-'.$parent_chapter->slug.'"></div>';
-			$output .= '<div class="comic-archive-series-description">'.$parent_chapter->description.'</div>';
+			$output .= '<h2 class="comic-archive-series-title">'.wp_kses_post($parent_chapter->name).'</h2>';
+			$output .= '<div class="'.esc_attr('comic-archive-image-'.$parent_chapter->slug).'"></div>';
+			$output .= '<div class="comic-archive-series-description">'.wp_kses_post($parent_chapter->description).'</div>';
 			$child_chapters = get_term_children( $parent_chapter->term_id, 'chapters' );
 			foreach ($child_chapters as $child) {
 				$child_term = get_term_by( 'id', $child, 'chapters' );
 				if ($child_term->count) {
 					$output .= '<div class="comic-archive-chapter-wrap">';
-					$output .= '<h3 class="comic-archive-chapter-title">'.$child_term->name.'</h3>';
-					$output .= '<div class="comic-archive-image-'.$child_term->slug.'"></div>';
-					$output .= '<div class="comic-archive-chapter-description">'.$child_term->description.'</div>';
+					$output .= '<h3 class="comic-archive-chapter-title">'.wp_kses_post($child_term->name).'</h3>';
+					$output .= '<div class="'.esc_attr('comic-archive-image-'.$child_term->slug).'"></div>';
+					$output .= '<div class="comic-archive-chapter-description">'.wp_kses_post($child_term->description).'</div>';
 					$child_args = array( 
 							'numberposts' => -1, 
 							'post_type' => 'comic',
@@ -293,7 +293,7 @@ function ceo_archive_list_series($thumbnail = 0) {
 					foreach ($qcposts as $qcpost) {
 						$archive_count++;
 						if ($css_alt) { $alternate = ' comic-list-alt'; $css_alt = false; } else { $alternate = ''; $css_alt=true; }		
-						$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qcpost->ID).'</span><span class="comic-archive-title"><a href="'.get_permalink($qcpost->ID).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qcpost->post_title).'">'.esc_html($qcpost->post_title).'</a></span></div>';
+						$output .= '<div class="comic-list comic-list-'.$archive_count.$alternate.'"><span class="comic-archive-date">'.get_the_time('M d, Y', $qcpost->ID).'</span><span class="comic-archive-title"><a href="'.esc_url(get_permalink($qcpost->ID)).'" rel="bookmark" title="'.esc_attr(__('Permanent Link:','comiceasel').' '.$qcpost->post_title).'">'.esc_html($qcpost->post_title).'</a></span></div>';
 					}
 					$output .= '</div>';
 					$output .= '<div style="clear:both;"></div></div>';	
@@ -330,7 +330,7 @@ function ceo_archive_list_by_chapter_thumbnails($order = 'ASC', $showtitle = fal
 				$qcposts = get_posts( $child_args );
 				$qcposts = reset($qcposts);
 				if (has_post_thumbnail($qcposts->ID)) {
-					$output .= '<div class="comic-archive-thumbnail"><a href="'.get_permalink($qcposts).'">'.get_the_post_thumbnail($qcposts->ID, 'thumbnail').'</a></div>';
+					$output .= '<div class="comic-archive-thumbnail"><a href="'.esc_url(get_permalink($qcposts)).'">'.get_the_post_thumbnail($qcposts->ID, 'thumbnail').'</a></div>';
 				} else $output .= __('No Thumbnail Found', 'comiceasel');
 			}
 		}
@@ -443,7 +443,7 @@ function ceo_archive_list_by_year($thumbnail = false, $order = 'ASC', $chapter =
 	}
 	$theposts = get_posts($comic_args);
 	foreach ($theposts as $post) {
-		$output .= '<tr><td class="archive-date">'.get_the_time('M j', $post).'</td><td class="archive-title"><a href="'.get_permalink($post->ID).'" rel="bookmark" title="'.get_the_title($post->ID).'">'.get_the_title($post->ID).'</a></td></tr>';
+		$output .= '<tr><td class="archive-date">'.get_the_time('M j', $post).'</td><td class="archive-title"><a href="'.esc_url(get_permalink($post->ID)).'" rel="bookmark" title="'.ceo_title_for_attribute($post->ID).'">'.ceo_title_for_html($post->ID).'</a></td></tr>';
 	}
 	$output .= '</table>';
 	return $output;
@@ -482,10 +482,10 @@ function ceo_archive_list_by_all_years($thumbnail = false, $order = 'ASC', $chap
 					);
 		}
 		$theposts = get_posts($comic_args);
-		$output .= '<h3 class="year-title">'.$year.'</h3>';
+		$output .= '<h3 class="year-title">'.esc_html($year).'</h3>';
 		$output .= '<table class="month-table">';			
 		foreach ($theposts as $post) {
-			$output .= '<tr><td class="archive-date">'.get_the_time('M j', $post->ID).'</td><td class="archive-title"><a href="'.get_permalink($post->ID).'" rel="bookmark" title="'.get_the_title($post->ID).'">'.get_the_title($post->ID).'</a></td></tr>';
+			$output .= '<tr><td class="archive-date">'.get_the_time('M j', $post->ID).'</td><td class="archive-title"><a href="'.esc_url(get_permalink($post->ID)).'" rel="bookmark" title="'.ceo_title_for_attribute($post->ID).'">'.ceo_title_for_html($post->ID).'</a></td></tr>';
 		}
 		$output .= '</table>';
 	}
@@ -506,12 +506,12 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 		switch ($action) {
 			case 'thankyou':
 				$buy_output .= '<div class="buycomic-thankyou">';
-				$buy_output .= $thanks;
+				$buy_output .= wp_kses_post($thanks);
 				$buy_output .= '</div>';
 				break;
 			case 'cancelled':
 				$buy_output .= '<div class="buycomic-cancelled">';
-				$buy_output .= $cancelled;
+				$buy_output .= wp_kses_post($cancelled);
 				$buy_output .= '</div>';
 				break;
 		}
@@ -537,7 +537,7 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 		// comic content before disclosing anything about it.
 		if (!is_wp_error($post) && !empty($post) && $post->post_type === 'comic' && $post->post_status === 'publish' && !post_password_required($post)) {
 			$buy_output .= __('Comic ID','comiceasel').' #'.$comicnum."<br />\r\n";
-			$buy_output .= __('Title:','comiceasel').'&nbsp;'.get_the_title($post)."<br />\r\n";
+			$buy_output .= __('Title:','comiceasel').'&nbsp;'.ceo_title_for_html($post)."<br />\r\n";
 			if (ceo_pluginfo('buy_comic_sell_print')) {
 				$buy_output .= __('Print Status:','comiceasel').'&nbsp;'.esc_html($buyprint_status)."<br />\r\n";
 			}
@@ -569,11 +569,11 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 					$buy_output .= '</form>';
 				}
 				if ($buyprint_status == __('Sold','comiceasel')) {
-					$buy_output .= '<img src="'.ceo_pluginfo('plugin_url').'images/sold.png" alt="'.__('Sold','comiceasel').'" />';
+					$buy_output .= '<img src="'.esc_url(ceo_pluginfo('plugin_url').'images/sold.png').'" alt="'.esc_attr(__('Sold','comiceasel')).'" />';
 				} elseif ($buyprint_status == __('Out Of Stock','comiceasel')) {
-					$buy_output .= '<img src="'.ceo_pluginfo('plugin_url').'images/outofstock.png" alt="'.__('Out Of Stock','comiceasel').'" />';
-				} elseif ($buyprint_status == __('Not Available','comiceasel')) { 
-					$buy_output .= '<img src="'.ceo_pluginfo('plugin_url').'images/notavailable.png" alt="'.__('Not Available','comiceasel').'" />';
+					$buy_output .= '<img src="'.esc_url(ceo_pluginfo('plugin_url').'images/outofstock.png').'" alt="'.esc_attr(__('Out Of Stock','comiceasel')).'" />';
+				} elseif ($buyprint_status == __('Not Available','comiceasel')) {
+					$buy_output .= '<img src="'.esc_url(ceo_pluginfo('plugin_url').'images/notavailable.png').'" alt="'.esc_attr(__('Not Available','comiceasel')).'" />';
 				}
 				$buy_output .= '</div>';
 				$buy_output .= '</td>';
@@ -600,11 +600,11 @@ function ceo_display_buycomic( $atts, $content = '' ) {
 					$buy_output .= '</form>';
 				}
 				if ($buyorig_status == __('Sold','comiceasel')) {
-					$buy_output .= '<img src="'.ceo_pluginfo('plugin_url').'images/sold.png" alt="'.__('Sold','comiceasel').'" />';
+					$buy_output .= '<img src="'.esc_url(ceo_pluginfo('plugin_url').'images/sold.png').'" alt="'.esc_attr(__('Sold','comiceasel')).'" />';
 				} elseif ($buyorig_status == __('Out Of Stock','comiceasel')) {
-					$buy_output .= '<img src="'.ceo_pluginfo('plugin_url').'images/outofstock.png" alt="'.__('Out Of Stock','comiceasel').'" />';
-				} elseif ($buyorig_status == __('Not Available','comiceasel')) { 
-					$buy_output .= '<img src="'.ceo_pluginfo('plugin_url').'images/notavailable.png" alt="'.__('Not Available','comiceasel').'" />';
+					$buy_output .= '<img src="'.esc_url(ceo_pluginfo('plugin_url').'images/outofstock.png').'" alt="'.esc_attr(__('Out Of Stock','comiceasel')).'" />';
+				} elseif ($buyorig_status == __('Not Available','comiceasel')) {
+					$buy_output .= '<img src="'.esc_url(ceo_pluginfo('plugin_url').'images/notavailable.png').'" alt="'.esc_attr(__('Not Available','comiceasel')).'" />';
 				}
 				$buy_output .= '</div>';
 				$buy_output .= '</td>';
@@ -669,7 +669,7 @@ function ceo_random_comic_shortcode($atts, $content = '') {
 			$the_permalink = get_permalink($post->ID);
 			$output = '<div class="rand-comic-wrap rand-comic-'.$post->ID.'">';
 			if ( has_post_thumbnail($post->ID) ) {
-				$output .= "<a href=\"".$the_permalink."\" rel=\"bookmark\" title=\"".get_the_title()."\">".get_the_post_thumbnail($post->ID, $size)."</a>\r\n";
+				$output .= '<a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.ceo_title_for_attribute($post->ID).'">'.get_the_post_thumbnail($post->ID, $size)."</a>\r\n";
 			} else {
 				$output .= __('No Thumbnail Found.','comiceasel');
 			}

--- a/tests/OutputEscapingTest.php
+++ b/tests/OutputEscapingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Late output escaping for public title and taxonomy surfaces.
+ */
+class OutputEscapingTest extends CE_TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		self::loadPluginFile( 'functions/library.php' );
+		self::loadPluginFile( 'functions/shortcodes.php' );
+	}
+
+	public function testTitleAttributeCannotCreateANewAttribute() {
+		CE_Test_State::$titles[7] = 'Boom" onmouseover="alert(1) & Co';
+
+		$escaped = ceo_title_for_attribute( 7 );
+
+		$this->assertSame( 'Boom&quot; onmouseover=&quot;alert(1) &amp; Co', $escaped );
+		$this->assertStringNotContainsString( '" onmouseover="', $escaped );
+	}
+
+	public function testHtmlTitleUsesKsesWithoutDoubleEncodingEntities() {
+		CE_Test_State::$titles[7] = '<em>A &amp; B</em><img src=x onerror=alert(1)>';
+
+		$this->assertSame(
+			CE_KSES_SENTINEL . '<em>A &amp; B</em><img src=x onerror=alert(1)>',
+			ceo_title_for_html( 7 )
+		);
+		$this->assertSame(
+			array( '<em>A &amp; B</em><img src=x onerror=alert(1)>' ),
+			CE_Test_State::$kses_calls
+		);
+	}
+
+	public function testCastOutputEscapesSlugAttributesAndFiltersVisibleMarkup() {
+		$character              = new stdClass();
+		$character->slug        = 'hero" onclick="alert(1)';
+		$character->name        = '<em>Hero &amp; Friend</em><script>alert(1)</script>';
+		$character->description = '<strong>Bio</strong><script>alert(2)</script>';
+		$character->count       = 1;
+
+		$output = ceo_cast_display( $character, false, true );
+
+		$this->assertStringContainsString( 'character-hero&quot; onclick=&quot;alert(1)', $output );
+		$this->assertStringNotContainsString( 'class="cast-pic character-hero" onclick="', $output );
+		$this->assertStringContainsString( CE_KSES_SENTINEL . $character->name, $output );
+		$this->assertStringContainsString( CE_KSES_SENTINEL . $character->description, $output );
+	}
+
+	public function testUnknownCharacterShortcodeEscapesTheReflectedName() {
+		$output = ceo_cast_page(
+			array( 'character' => '<img src=x onerror=alert(1)>' )
+		);
+
+		$this->assertStringContainsString( '&lt;img src=x onerror=alert(1)&gt;', $output );
+		$this->assertStringNotContainsString( '<img', $output );
+	}
+
+	public function testBuyComicMessagesPreserveAllowedMarkupThroughKses() {
+		$_REQUEST['action'] = 'thankyou';
+		$message = '<em>Thanks &amp; welcome</em><script>alert(1)</script>';
+
+		try {
+			$output = ceo_display_buycomic( array( 'thanks' => $message ) );
+		} finally {
+			unset( $_REQUEST['action'] );
+		}
+
+		$this->assertStringContainsString( CE_KSES_SENTINEL . $message, $output );
+		$this->assertContains( $message, CE_Test_State::$kses_calls );
+	}
+}

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -34,6 +34,8 @@ class CE_Test_State {
 	public static $translations = array();
 	/** @var array<string,mixed> ceo_pluginfo key => value */
 	public static $pluginfo = array();
+	/** @var array<int,string> post ID => filtered post title */
+	public static $titles = array();
 	/** @var mixed value returned by wp_remote_post() */
 	public static $http_response = array();
 	/** @var array recorded wp_remote_post() calls */
@@ -52,6 +54,7 @@ class CE_Test_State {
 		self::$filters = array();
 		self::$translations = array();
 		self::$pluginfo = array();
+		self::$titles = array();
 		self::$http_response = array();
 		self::$http_requests = array();
 		self::$kses_calls = array();
@@ -378,9 +381,22 @@ if ( ! function_exists( 'get_permalink' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term, $taxonomy = '' ) {
+		return 'https://example.test/' . $taxonomy . '/' . $term;
+	}
+}
+
+if ( ! function_exists( 'get_term_by' ) ) {
+	function get_term_by( $field, $value, $taxonomy = '', $output = 'OBJECT', $filter = 'raw' ) {
+		return false;
+	}
+}
+
 if ( ! function_exists( 'get_the_title' ) ) {
 	function get_the_title( $post = 0 ) {
-		return 'Title';
+		$post_id = is_object( $post ) && isset( $post->ID ) ? (int) $post->ID : (int) $post;
+		return array_key_exists( $post_id, CE_Test_State::$titles ) ? CE_Test_State::$titles[ $post_id ] : 'Title';
 	}
 }
 

--- a/widgets/archive-dropdown.php
+++ b/widgets/archive-dropdown.php
@@ -61,17 +61,17 @@ function ceo_taxonomy_walker_dropdown_or_list_start_el( &$output, $category, $de
 	
 	if ($args['render_as_list']) {
 		
-		$output .= "\t<li class=\"level-$depth $css_classes\"><a href=\"".$permalink."\">";
+		$output .= "\t<li class=\"".esc_attr("level-$depth $css_classes")."\"><a href=\"".esc_url($permalink)."\">";
 	} else {
-        $output .= "\t<option class=\"level-$depth\" value=\"".$permalink."\"";
+        $output .= "\t<option class=\"".esc_attr("level-$depth")."\" value=\"".esc_url($permalink)."\"";
         if ( $value === (string) $args['selected'] ) {   
             $output .= ' selected="selected"';
         }
        	$output .= '>';
 	}
-    $output .= $pad.$cat_name;
+    $output .= $args['render_as_list'] ? wp_kses_post($pad.$cat_name) : esc_html($pad.$cat_name);
     if ( $args['show_count'] )
-        $output .= '&nbsp;&nbsp;('. $category->count .')';
+        $output .= '&nbsp;&nbsp;('. (int)$category->count .')';
 	$output .= ($args['render_as_list']) ? "</a>" : "</option>\n";
 }
 

--- a/widgets/casthover.php
+++ b/widgets/casthover.php
@@ -45,7 +45,7 @@ function ceo_casthover_res_init_scripts() {
 function ceo_insert_character_hovercard($character) {
 	$ccard = '';
 	if ($character) {
-		$ccard .= '<div class="casthover-hovercard" id="chc-'.$character.'">';
+		$ccard .= '<div class="casthover-hovercard" id="'.esc_attr('chc-'.$character).'">';
 		$ccard .= do_shortcode('[cast-page character="'.$character.'"]');
 		$ccard .= '</div>';
 	}
@@ -60,7 +60,7 @@ function ceo_add_characters_hovercards($post_characters) {
 	if ( !empty( $terms ) ) {
 		$out = array();
 		foreach ( $terms as $term ) {
-			$out[] = '<span class="casthover-hovercard-hook"><a href="'.get_term_link($term->slug, 'characters').'">'.$term->name.'</a>'.ceo_insert_character_hovercard($term->slug).'</span>';
+			$out[] = '<span class="casthover-hovercard-hook"><a href="'.esc_url(get_term_link($term->slug, 'characters')).'">'.wp_kses_post($term->name).'</a>'.ceo_insert_character_hovercard($term->slug).'</span>';
 		}
 		$return = join( ', ', $out );
 	}
@@ -110,7 +110,7 @@ class ceo_casthover_reference_widget extends WP_Widget {
 				}				
 				?><div class="castrefwidget-wrapper"><?php 
 				foreach ( $post_characters as $mychar ) {
-					$out[] = '<span class="castrefwidget-line casthover-hovercard-hook"><a href="'.get_term_link($mychar->slug, 'characters').'"><div class="castrefwidget-block character-'.$mychar->slug.'"></div></a>'.ceo_insert_character_hovercard($mychar->slug).'</span>';
+					$out[] = '<span class="castrefwidget-line casthover-hovercard-hook"><a href="'.esc_url(get_term_link($mychar->slug, 'characters')).'"><div class="'.esc_attr('castrefwidget-block character-'.$mychar->slug).'"></div></a>'.ceo_insert_character_hovercard($mychar->slug).'</span>';
 				}
 				echo join('',$out);
 				?></div><?php 

--- a/widgets/comicblogpost.php
+++ b/widgets/comicblogpost.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) exit;
 
 function ceo_display_comic_small_blog_post($instance) {
 	global $post;
-	if ($instance['showtitle']) { echo "<h3 class=\"comic-post-widget-title\">".get_the_title()."</h3>\r\n"; }
+	if ($instance['showtitle']) { echo '<h3 class="comic-post-widget-title">'.ceo_title_for_html($post->ID)."</h3>\r\n"; }
 	if ($instance['showdate']) { echo "<div class=\"comic-post-widget-date\">".get_the_time(get_option('date_format'))."</div>\r\n"; }
 	the_content();
 	if ($instance['showcommentlink'] && ($post->comment_status == 'open') && !is_singular()) { ?>

--- a/widgets/comiclist-dropdown.php
+++ b/widgets/comiclist-dropdown.php
@@ -30,7 +30,7 @@ function ceo_list_jump_to_comic($exclude = '', $return = false) {
 		$qposts = get_posts( $post_args );
 		foreach($qposts as $qpost) {
 			$permalink = get_permalink($qpost->ID);
-			if (!empty($permalink)) $output .='<option class="level-0" value="'.esc_url($permalink).'">'.$qpost->post_title.'</option>';
+			if (!empty($permalink)) $output .='<option class="level-0" value="'.esc_url($permalink).'">'.esc_html($qpost->post_title).'</option>';
 		}
 		$output .= '</select>';
 		$output .= '<noscript>';

--- a/widgets/navigation.php
+++ b/widgets/navigation.php
@@ -52,7 +52,7 @@ class ceo_comic_navigation_widget extends WP_Widget {
 				<?php if ($instance['comictitle']) { echo '- '; }
 			}
 			if ($instance['comictitle']) { ?>
-				<span class="navi-comictitle"><a href="<?php the_permalink(); ?>" class="comic-nav-title">"<?php the_title(); ?>"</a></span>
+				<span class="navi-comictitle"><a href="<?php echo esc_url(get_permalink($post->ID)); ?>" class="comic-nav-title">"<?php echo ceo_title_for_html($post->ID); ?>"</a></span>
 			<?php } ?>
 			</td>
 			</tr>

--- a/widgets/recentcomics.php
+++ b/widgets/recentcomics.php
@@ -36,7 +36,7 @@ class ceo_latest_comics_widget extends WP_Widget {
 		$latestcomics = get_posts($args); ?>
 		<ul>
 		<?php foreach($latestcomics as $post) : ?>
-			<li><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></li>
+			<li><a href="<?php echo esc_url(get_permalink($post->ID)); ?>"><?php echo ceo_title_for_html($post->ID); ?></a></li>
 		<?php endforeach; ?>
 		</ul>
 		<?php

--- a/widgets/scheduledcomics.php
+++ b/widgets/scheduledcomics.php
@@ -41,7 +41,7 @@ class ceo_scheduled_comics_widget extends WP_Widget {
 		} else { ?>
 			<ul>
 			<?php foreach($scheduled_posts as $post) : ?>
-				<li><span class="scheduled-post-date"><?php echo date('m/d/Y',strtotime($post->post_date)); ?></span> <span class="scheduled-post-title"><?php echo $post->post_title; ?></span></li>
+				<li><span class="scheduled-post-date"><?php echo esc_html(date('m/d/Y',strtotime($post->post_date))); ?></span> <span class="scheduled-post-title"><?php echo wp_kses_post($post->post_title); ?></span></li>
 			<?php endforeach; ?>
 			</ul>
 		<?php } 

--- a/widgets/thumbnail.php
+++ b/widgets/thumbnail.php
@@ -58,27 +58,27 @@ class ceo_thumbnail_widget extends WP_Widget {
 				$the_permalink = get_permalink($post->ID);
 				if (!isset($instance['same'])) $instance['same'] = false;
 				if (!($instance['same'] && ($the_permalink == $current_permalink))) {
-					echo '<div class="comic-thumb-wrap comic-thumb-'.$post->ID.'">';
+					echo '<div class="comic-thumb-wrap comic-thumb-'.(int)$post->ID.'">';
 					if ($instance['centering']) echo "\r\n<center>\r\n";
 					if (isset($instance['secondary']) && $instance['secondary'] && class_exists('MultiPostThumbnails')) {
 						$secondary_image = MultiPostThumbnails::get_the_post_thumbnail(get_post_type(), 'secondary-image', $post->ID,  'secondary-image');
 						if (!empty($secondary_image)) {
-							echo '<a href="'.$the_permalink.'" rel="bookmark" title="'.__('Permanent Link to','comiceasel').' '.get_the_title().'">'.$secondary_image.'</a>'."\r\n";
+							echo '<a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.esc_attr(__('Permanent Link to','comiceasel').' '.get_the_title()).'">'.$secondary_image.'</a>'."\r\n";
 						} else {
 							if ( has_post_thumbnail($post->ID) ) {
-								echo '<a href="'.$the_permalink.'" rel="bookmark" title="'.__('Permanent Link to','comiceasel').' '.get_the_title().'">'.get_the_post_thumbnail($post->ID, $thumbnail_size).'</a>'."\r\n";
+								echo '<a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.esc_attr(__('Permanent Link to','comiceasel').' '.get_the_title()).'">'.get_the_post_thumbnail($post->ID, $thumbnail_size).'</a>'."\r\n";
 							} else {
 								echo __('No Thumbnail Found.','comiceasel');	
 							}							
 						}
 					} else {
 						if ( has_post_thumbnail($post->ID) ) {
-							echo '<a href="'.$the_permalink.'" rel="bookmark" title="'.__('Permanent Link to','comiceasel').' '.get_the_title().'">'.get_the_post_thumbnail($post->ID, $thumbnail_size).'</a>'."\r\n";
+							echo '<a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.esc_attr(__('Permanent Link to','comiceasel').' '.get_the_title()).'">'.get_the_post_thumbnail($post->ID, $thumbnail_size).'</a>'."\r\n";
 						} else {
 							echo __('No Thumbnail Found.','comiceasel');	
 						}
 					}
-					if ($instance['linktitle']) { echo '<div class="comic-thumb-title"><a href="'.$the_permalink.'" rel="bookmark" title="'.__('Permanent Link to','comiceasel').' '.get_the_title().'">'.get_the_title().'</a></div><div class="clear"></div>'; }
+					if ($instance['linktitle']) { echo '<div class="comic-thumb-title"><a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.esc_attr(__('Permanent Link to','comiceasel').' '.get_the_title()).'">'.ceo_title_for_html($post->ID).'</a></div><div class="clear"></div>'; }
 					if ($instance['showdate']) { echo '<div class="comic-thumb-date">'.get_the_date(get_option('date_format')).'</div>'; }
 					if ($instance['centering']) echo "\r\n</center>\r\n";
 					echo "</div>\r\n";
@@ -127,9 +127,9 @@ class ceo_thumbnail_widget extends WP_Widget {
 		<?php 
 			$thumbnail_sizes = get_intermediate_image_sizes();
 			foreach ($thumbnail_sizes as $size) { ?>
-				<option class="level-0" value="<?php echo $size; ?>" <?php selected( $thumbnail_size, $size); ?>><?php echo ucfirst($size); ?></option>
+				<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $thumbnail_size, $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 		<?php } ?>
-				<option class="level-0" value="full" <?php selected($thumbnail_size, 'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>							
+			<option class="level-0" value="full" <?php selected($thumbnail_size, 'full'); ?>><?php esc_html_e('Full', 'comiceasel'); ?></option>
 		</select></p>
 		<p><?php _e('Which Chapter?', 'comiceasel'); ?><br />	
 		<?php 
@@ -142,7 +142,7 @@ class ceo_thumbnail_widget extends WP_Widget {
 			foreach ($allterms as $term) {
 				$chaptselected = '';
 				if ($thumbchapt == $term->slug) $chaptselected = 'selected';
-				$chapter_options .= '<option name="'.$term->slug.'" value="'.$term->slug.'" '.$chaptselected.'> '.$term->name.' </option>';
+				$chapter_options .= '<option name="'.esc_attr($term->slug).'" value="'.esc_attr($term->slug).'" '.$chaptselected.'> '.esc_html($term->name).' </option>';
 			}
 			?>
 			<select name="<?php echo $this->get_field_name('thumbchapt'); ?>" id="<?php echo $this->get_field_id('thumbchapt'); ?>">
@@ -153,7 +153,7 @@ class ceo_thumbnail_widget extends WP_Widget {
 		<p><label for="<?php echo $this->get_field_id('first'); ?>"><?php _e('Get first in chapter instead?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('first'); ?>" name="<?php echo $this->get_field_name('first'); ?>" type="checkbox" value="1" <?php checked(true, $first); ?> /></label></p>		
 		<p><label for="<?php echo $this->get_field_id('random'); ?>"><?php _e('Display a random Thumbnail?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('random'); ?>" name="<?php echo $this->get_field_name('random'); ?>" type="checkbox" value="1" <?php checked(true, $random); ?> /></label></p>
 		<p><em><?php _e('*note: Random thumbnail overrides the get first in chapter option.','comiceasel'); ?></em></p>
-		<p><?php _e('Display how many thumbnails?', 'comiceasel'); ?><input style="width:40px;" id="<?php echo $this->get_field_id('thumbcount'); ?>" name="<?php echo $this->get_field_name('thumbcount'); ?>" type="text" value="<?php echo stripcslashes($instance['thumbcount']); ?>" /></label></p>
+		<p><?php esc_html_e('Display how many thumbnails?', 'comiceasel'); ?><input style="width:40px;" id="<?php echo $this->get_field_id('thumbcount'); ?>" name="<?php echo $this->get_field_name('thumbcount'); ?>" type="text" value="<?php echo esc_attr(stripcslashes($instance['thumbcount'])); ?>" /></label></p>
 		<p><label for="<?php echo $this->get_field_id('linktitle'); ?>"><?php _e('Include comic title?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('linktitle'); ?>" name="<?php echo $this->get_field_name('linktitle'); ?>" type="checkbox" value="1" <?php checked(true, $linktitle); ?> /></label></p>
 		<p><label for="<?php echo $this->get_field_id('centering'); ?>"><?php _e('Add centering html?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('centering'); ?>" name="<?php echo $this->get_field_name('centering'); ?>" type="checkbox" value="1" <?php checked(true, $centering); ?> /></label></p>
 		<p><label for="<?php echo $this->get_field_id('showdate'); ?>"><?php _e('Show the date of the post under image?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('showdate'); ?>" name="<?php echo $this->get_field_name('showdate'); ?>" type="checkbox" value="1" <?php checked(true, $showdate); ?> /></label></p>
@@ -165,4 +165,3 @@ class ceo_thumbnail_widget extends WP_Widget {
 	<?php
 	}
 }
-


### PR DESCRIPTION
## Summary

- escape filterable titles, taxonomy data, URLs, reflected values, and generated attributes at their public output sinks
- preserve legitimate inline title and term markup with WordPress KSES
- add regression coverage for attribute breakout, reflected shortcode values, and the KSES boundary

## Compatibility

Escaping happens only at render time; no stored values are rewritten. Existing permitted markup and intentional theme/plugin HTML surfaces remain supported.

## Testing

- PHPUnit: 146 tests, 202 assertions
- PHP syntax checks and `git diff --check`
- activated and exercised in WordPress 7.0.2 on PHP 8.5.8, including parsed-DOM browser checks

Co-authored by gpt-5.6-sol.
