### PR TITLE
Declare jQuery dependency for key navigation

### DIFF
--- a/comiceasel.php
+++ b/comiceasel.php
@@ -600,6 +600,6 @@ function ceo_run_scripts() {
 		}
 	}
 	if (!ceo_pluginfo('disable_keynav')) {
-		wp_enqueue_script('ceo_keynav', ceo_pluginfo('plugin_url').'js/keynav.js', null, null, true);
+		wp_enqueue_script('ceo_keynav', ceo_pluginfo('plugin_url').'js/keynav.js', array('jquery'), null, true);
 	}
 }


### PR DESCRIPTION
## Summary

Declare jQuery as a dependency of `keynav.js` so WordPress loads it first. This fixes `jQuery is not defined` on themes that do not otherwise enqueue jQuery.

## Testing

- PHPUnit: 141 tests, 190 assertions
- PHP syntax check, `git diff --check`, and changed-line PHPCS

Co-authored by gpt-5.6-sol.
