### PR TITLE
Load PayPal helpers in output escaping tests

### DIFF
--- a/tests/OutputEscapingTest.php
+++ b/tests/OutputEscapingTest.php
@@ -9,6 +9,7 @@ class OutputEscapingTest extends CE_TestCase {
 		parent::setUp();
 		self::loadPluginFile( 'functions/library.php' );
 		self::loadPluginFile( 'functions/shortcodes.php' );
+		self::loadPluginFile( 'functions/redirects.php' );
 	}
 
 	public function testTitleAttributeCannotCreateANewAttribute() {


### PR DESCRIPTION
## Summary

Load `functions/redirects.php` in `OutputEscapingTest`, which now exercises PayPal helpers used by `ceo_display_buycomic()`.

This is test-harness-only. WordPress already loads both plugin files before shortcode callbacks can run.

## Testing

- PHPUnit: 156 tests, 222 assertions
- PHP syntax checks, `git diff --check`, and changed-line PHPCS

Co-authored by gpt-5.6-sol.
