### PR TITLE
Escape output flagged by Plugin Check

### DIFF
--- a/ceo-config.php
+++ b/ceo-config.php
@@ -2,7 +2,7 @@
 <div class="wrap">
 	<div id="ceoadmin-headericon" style="background: url('<?php echo ceo_pluginfo('plugin_url') ?>images/easel_small.png') no-repeat;"></div>
 <p class="alignleft">
-	<h2><?php _e('Comic Easel - Config','comiceasel'); ?></h2>
+	<h2><?php esc_html_e('Comic Easel - Config','comiceasel'); ?></h2>
 </p>
 <div class="clear"></div>
 <?php
@@ -21,7 +21,7 @@ if ($action == 'comiceasel_reset') {
 	$ceo_pluginfo = array();
 	ceo_load_options('reset');
 	?>
-			<div id="message" class="updated"><p><strong><?php _e('Comic Easel Settings RESET!','comiceasel'); ?></strong></p></div>
+			<div id="message" class="updated"><p><strong><?php esc_html_e('Comic Easel Settings RESET!','comiceasel'); ?></strong></p></div>
 	<?php
 }
 $ceo_options = get_option('comiceasel-config');
@@ -166,7 +166,7 @@ if ( wp_verify_nonce($nonce, 'update-options') ) {
 		}
 		
 		if ($tab) { ?>
-			<div id="message" class="updated"><p><strong><?php _e('Comic Easel Settings SAVED!','comiceasel'); ?></strong></p></div>
+			<div id="message" class="updated"><p><strong><?php esc_html_e('Comic Easel Settings SAVED!','comiceasel'); ?></strong></p></div>
 			<script>function hidemessage() { document.getElementById('message').style.display = 'none'; }</script>
 		<?php }
 	} 
@@ -187,7 +187,7 @@ if ( wp_verify_nonce($nonce, 'update-options') ) {
 		  	if (empty($tab)) { $tab = 'main'; }
 
 		  	foreach($tab_info as $tab_id => $label) { ?>
-		  		<div id="comiceasel-tab-<?php echo $tab_id ?>" class="comiceasel-tab <?php echo ($tab == $tab_id) ? 'on' : 'off'; ?>"><span><?php echo $label; ?></span></div>
+		  		<div id="comiceasel-tab-<?php echo esc_attr($tab_id) ?>" class="comiceasel-tab <?php echo ($tab == $tab_id) ? 'on' : 'off'; ?>"><span><?php echo esc_html($label); ?></span></div>
 		  	<?php }
 		  ?>
 		</div>
@@ -223,8 +223,8 @@ if ( wp_verify_nonce($nonce, 'update-options') ) {
 
 	<div class="ceoadmin-footer">
 		<br />
-		<a href="https://github.com/Frumph/comic-easel"><?php _e('Comic Easel','comiceasel'); ?></a> <?php _e('created, developed and maintained by','comiceasel'); ?> <a href="http://frumph.net/">Philip M. Hofer</a> <small>(<a href="http://frumph.net/">Frumph</a>)</small><br />
-		<?php _e('If you like the Comic Easel plugin, please donate.  It will help in developing new features and versions.','comiceasel'); ?><br />
+		<a href="https://github.com/Frumph/comic-easel"><?php esc_html_e('Comic Easel','comiceasel'); ?></a> <?php esc_html_e('created, developed and maintained by','comiceasel'); ?> <a href="http://frumph.net/">Philip M. Hofer</a> <small>(<a href="http://frumph.net/">Frumph</a>)</small><br />
+		<?php esc_html_e('If you like the Comic Easel plugin, please donate.  It will help in developing new features and versions.','comiceasel'); ?><br />
 		<table style="margin:0 auto;">
 			<tr>
 				<td style="width:200px;">

--- a/ceo-debug.php
+++ b/ceo-debug.php
@@ -21,11 +21,11 @@ function ceo_check_directory($dirpath) {
 
 ?>
 <div class="wrap">
-<h2><?php _e('Comic Easel - Debug','comiceasel'); ?></h2>
+<h2><?php esc_html_e('Comic Easel - Debug','comiceasel'); ?></h2>
 <table class="widefat">
 <thead>
 	<tr>
-	<th colspan="3"><?php _e('System Info','comiceasel'); ?></th>
+	<th colspan="3"><?php esc_html_e('System Info','comiceasel'); ?></th>
 	</tr>
 </thead>
 <tr><td>error</td><td><?php echo esc_html(ceo_pluginfo('error')); ?></td></tr>
@@ -44,7 +44,7 @@ function ceo_check_directory($dirpath) {
 <thead>
 <tr>
 <th colspan = "3">
-	<?php _e('Variables', 'comiceasel'); ?>
+	<?php esc_html_e('Variables', 'comiceasel'); ?>
 </th>
 </tr>
 </thead>

--- a/ceo-import.php
+++ b/ceo-import.php
@@ -106,31 +106,31 @@ function ceo_import_add_comic_and_post($comic_to_add, $date_to_add, $title_to_ad
 }
 
 function ceo_import_by_namedate($import_directory, $import_date_format, $import_filename_mask, $import_create_post, $import_chapter, $import_time) {
-	echo '<strong><h2>'.__('Import type: by Filename w/date','comiceasel').'</strong></h2>';
+	echo '<strong><h2>'.esc_html__('Import type: by Filename w/date','comiceasel').'</strong></h2>';
 	$file_list = array();
 	if (count($results = glob(ABSPATH.$import_directory.'/*.*')) > 0) {
-		echo count($results).' '.__('Files found.','comiceasel')."<br />\r\n";
+		echo count($results).' '.esc_html__('Files found.','comiceasel')."<br />\r\n";
 		natcasesort($results);
 		foreach ($results as $filename) {
 			$breakdown = ceo_breakdown_comic_filename(basename($filename), $import_date_format, $import_filename_mask);
 			if ($breakdown && is_array($breakdown)) $file_list[] = $breakdown;
 		}
-		echo count($file_list).' '.__('files have valid naming and can be imported.','comiceasel');
+		echo count($file_list).' '.esc_html__('files have valid naming and can be imported.','comiceasel');
 	} else {
-		echo __('No files found in','comiceasel').' '.ABSPATH.$import_directory.' '.__('or directory does not exist','comiceasel').'<br />';
+		echo esc_html__('No files found in','comiceasel').' '.esc_html(ABSPATH.$import_directory).' '.esc_html__('or directory does not exist','comiceasel').'<br />';
 		return;
 	}
 	echo "<hr />\r\n";
 	if (count($file_list)) {
 		$chapter_object = get_term_by('id', $import_chapter, 'chapters');
-		echo __('Processing Files...','comiceasel').' '.__('Importing to chapter:','comiceasel').' <strong>'.$chapter_object->name.'</strong><br />'."\r\n";
+		echo esc_html__('Processing Files...','comiceasel').' '.esc_html__('Importing to chapter:','comiceasel').' <strong>'.esc_html($chapter_object->name).'</strong><br />'."\r\n";
 		echo '<table>';
 		foreach ($file_list as $file_to_process) {
 			echo '<tr>';
 			if (empty($file_to_process['converted_title'])) $file_to_process['converted_title'] = $file_to_process['date'];
 			$result = ceo_import_add_comic_and_post($file_to_process['filename'], $file_to_process['date'], $file_to_process['converted_title'], $import_create_post, $import_chapter, $import_time, $import_directory);
 			$result = ($result) ? $result : __('System Process Error','comiceasel');
-			echo '<td>'.__('Date:','comiceasel').' <strong>'.$file_to_process['date'].'</strong></td><td> ---- </td><td>'.__('Title of Post:','comiceasel').' <strong>'.$file_to_process['converted_title'].'</strong></td><td> --- </td><td>'.__('Result:','comiceasel').' <strong>'.$result.'</strong></td>';
+			echo '<td>'.esc_html__('Date:','comiceasel').' <strong>'.esc_html($file_to_process['date']).'</strong></td><td> ---- </td><td>'.esc_html__('Title of Post:','comiceasel').' <strong>'.esc_html($file_to_process['converted_title']).'</strong></td><td> --- </td><td>'.esc_html__('Result:','comiceasel').' <strong>'.$result.'</strong></td>';
 			echo '</tr>';
 		}
 		echo '</table>';
@@ -146,20 +146,20 @@ if ($import_request_is_valid) {
 			ceo_import_by_namedate($import_directory, $import_date_format, $import_filename_mask, $import_create_post, $import_chapter, $import_time);
 			break;
 		default:
-			_e('ERROR: No selection made.', 'comiceasel');
+			esc_html_e('ERROR: No selection made.', 'comiceasel');
 			break;
 	}
 }
 
 ?>
 <div class="wrap">
-<h2><?php _e('Comic Easel - Import','comiceasel'); ?></h2>
+<h2><?php esc_html_e('Comic Easel - Import','comiceasel'); ?></h2>
 <form method="post" id="myForm-import" name="template">
 <?php wp_nonce_field('comiceasel-import') ?>
 <table class="widefat">
 <thead>
 	<tr>
-	<th colspan="10"><?php _e('Options','comiceasel'); ?></th>
+	<th colspan="10"><?php esc_html_e('Options','comiceasel'); ?></th>
 	</tr>
 <?php 
 	/*
@@ -168,7 +168,7 @@ if ($import_request_is_valid) {
 			<input name="import-type" class="import-type" type="radio" value="date" disabled="disabled" />
 		</td>
 		<td valign="top" align="left" colspan="12">
-			<?php _e('by Date Stamp of file','comiceasel'); ?>
+			<?php esc_html_e('by Date Stamp of file','comiceasel'); ?>
 		</td>
 	</tr>
 	*/
@@ -178,27 +178,27 @@ if ($import_request_is_valid) {
 			<input name="import-type" class="import-type" type="radio" value="namedate" <?php checked($import_type, true); ?> />
 		</td>
 		<td align="left" style="width:180px">
-			<?php _e('by Filename w/date','comiceasel'); ?> <cite>(*1)</cite>
+			<?php esc_html_e('by Filename w/date','comiceasel'); ?> <cite>(*1)</cite>
 		</td>
 		<td align="left" style="width:260px">
-			<?php _e('Date Format','comiceasel'); ?><br />
-			<a href="http://codex.wordpress.org/Formatting_Date_and_Time" target="_blank"><?php _e('Documentation on date formats','comiceasel'); ?></a><br />
+			<?php esc_html_e('Date Format','comiceasel'); ?><br />
+			<a href="http://codex.wordpress.org/Formatting_Date_and_Time" target="_blank"><?php esc_html_e('Documentation on date formats','comiceasel'); ?></a><br />
 			<input name="import-date-format" class="import-date-format" value="<?php echo esc_attr($import_date_format); ?>" />
 		</td>
 		<td align="left" style="width:240px;">
-			<?php _e('Filename Mask','comiceasel'); ?><br />
-			{DATE} <?php _e('will be replaced','comiceasel'); ?><br />
+			<?php esc_html_e('Filename Mask','comiceasel'); ?><br />
+			{DATE} <?php esc_html_e('will be replaced','comiceasel'); ?><br />
 			<input name="import-date-mask" class="import-date-mask" value="<?php echo esc_attr($import_filename_mask); ?>" />
 		</td>
 		<td align="left" colspan="9">
-			<?php _e('Set Time of Comic Posts','comiceasel'); ?><br />
-			<?php _e('24 hour clock','comiceasel'); ?><br />
+			<?php esc_html_e('Set Time of Comic Posts','comiceasel'); ?><br />
+			<?php esc_html_e('24 hour clock','comiceasel'); ?><br />
 			<input name="import-time" class="import-time" value="<?php echo esc_attr($import_time); ?>" />
 		</td>
 	</tr>
 	<tr>
 		<td colspan="13">
-		<?php echo '<center><strong>'.__('WARNING: When uploading your comics to the import directory, make sure there is only 1 comic per day, multiple comics per day will have issues.','comiceasel').'</strong></center>';  ?>
+		<?php echo '<center><strong>'.esc_html__('WARNING: When uploading your comics to the import directory, make sure there is only 1 comic per day, multiple comics per day will have issues.','comiceasel').'</strong></center>';  ?>
 		</td>
 	</tr>
 <?php 
@@ -208,15 +208,15 @@ if ($import_request_is_valid) {
 			<input name="import-type" class="import-type" type="radio" value="numbered" disabled="disabled" />
 		</td>
 		<td align="left">
-			<?php _e('by Numbered filename','comiceasel'); ?>
+			<?php esc_html_e('by Numbered filename','comiceasel'); ?>
 		</td>
 		<td align="left">
-			<?php _e('Filename Mask','comiceasel'); ?><br />
-			{NUM} <?php _e('gets replaced with the comic number, starting at 1 - use Backdate Files option', 'comiceasel'); ?><br />
+			<?php esc_html_e('Filename Mask','comiceasel'); ?><br />
+			{NUM} <?php esc_html_e('gets replaced with the comic number, starting at 1 - use Backdate Files option', 'comiceasel'); ?><br />
 			<input name="import-filename-mask" class="import-filename-mask" value="comic{NUM}.*" disabled="disabled" />
 		</td>
 		<td align="left">
-			<input name="import-backdate" class="import-backdate" type="checkbox" value="1" checked disabled="disabled" /> <?php _e('Backdate Files', 'comiceasel'); ?><br />
+			<input name="import-backdate" class="import-backdate" type="checkbox" value="1" checked disabled="disabled" /> <?php esc_html_e('Backdate Files', 'comiceasel'); ?><br />
 			<input name="import-backdate-how" class="import-backdate-how-everyday" type="radio" value="everyday" disabled="disabled" /> Everyday<br />
 			<input name="import-backdate-how" class="import-backdate-how-weekdays" type="radio" value="weekdays" disabled="disabled" /> Weekdays<br />			
 			<input name="import-backdate-how" class="import-backdate-how-mwf" type="radio" value="mwf" disabled="disabled" /> MWF
@@ -231,10 +231,10 @@ if ($import_request_is_valid) {
 			<input name="import-create-post" class="import-create-post" type="checkbox" value="1" <?php checked($import_create_post, true); ?> />
 		</td>
 		<td align="left">
-			<?php _e('Import even if comic post already exists for that date.','comiceasel'); ?>
+			<?php esc_html_e('Import even if comic post already exists for that date.','comiceasel'); ?>
 		</td>
 		<td align="left" colspan="11">
-			<?php _e('Having this NOT checked (default) will make it so that if there is already a comic for that date it will not add another one.', 'comiceasel'); ?>
+			<?php esc_html_e('Having this NOT checked (default) will make it so that if there is already a comic for that date it will not add another one.', 'comiceasel'); ?>
 		</td>
 	</tr>
 */
@@ -259,40 +259,40 @@ wp_dropdown_categories( $args );
 
 		</td>
 		<td align="left" colspan="11">
-			<?php _e('Select a chapter the comics will go in.  If there are multiple chapters, then modify the comics in the import directory and only add the ones you want for the chapter selected.  You need to create the chapter first in the comics - chapters area.', 'comiceasel'); ?>
+			<?php esc_html_e('Select a chapter the comics will go in.  If there are multiple chapters, then modify the comics in the import directory and only add the ones you want for the chapter selected.  You need to create the chapter first in the comics - chapters area.', 'comiceasel'); ?>
 		</td>
 	</tr>
 </thead>
 </table>
 <p class="submit" style="margin-left: 10px;">
-	<input type="submit" class="button-primary" value="<?php _e('Import','comiceasel') ?>" />
+	<input type="submit" class="button-primary" value="<?php esc_attr_e('Import','comiceasel') ?>" />
 	<input type="hidden" name="action" value="ceo-import" />
 </p>
 <p>
 <?php 
-echo '<h3>'.__('DIRECTIONS:','comiceasel').'</h3>';
+echo '<h3>'.esc_html__('DIRECTIONS:','comiceasel').'</h3>';
 echo '<ol>';
-echo '<li>'.__('FTP into your site and create a directory named','comiceasel').' <strong>"'.$import_directory.'"</strong> '.__('off of the root installation folder of your site.','comiceasel').'</li>';
-echo '<li>'.__('Upload into that directory the comics using the ComicPress filename convention for each individual chapter you are importing.','comiceasel').'</li>';
-echo '<li>'.__('Make sure the chapter the comics are going into is created in the comic - chapters section of the wp-admin.','comiceasel').'</li>';
-echo '<li>'.__('Select chapter in the import section, modify any other values as needed, if you do not know what they are, do not modify them.','comiceasel').'</li>';
-echo '<li>'.__('Press the Import button and wish for the best.','comiceasel').'</li>';
+echo '<li>'.esc_html__('FTP into your site and create a directory named','comiceasel').' <strong>"'.esc_html($import_directory).'"</strong> '.esc_html__('off of the root installation folder of your site.','comiceasel').'</li>';
+echo '<li>'.esc_html__('Upload into that directory the comics using the ComicPress filename convention for each individual chapter you are importing.','comiceasel').'</li>';
+echo '<li>'.esc_html__('Make sure the chapter the comics are going into is created in the comic - chapters section of the wp-admin.','comiceasel').'</li>';
+echo '<li>'.esc_html__('Select chapter in the import section, modify any other values as needed, if you do not know what they are, do not modify them.','comiceasel').'</li>';
+echo '<li>'.esc_html__('Press the Import button and wish for the best.','comiceasel').'</li>';
 echo '</ol>'
 ?>
 </p>
-<cite>*1</cite> - <?php _e('eg, ComicPress style filenames, if Date Format is: Y-m-d and Date Mask is {DATE}*.* the filename would be (as example if image is a .jpg):','comiceasel'); ?> <strong><?php _e('2012-01-01-title-of-comic.jpg','comiceasel'); ?></strong><br />
-<cite>*2</cite> - <?php _e('ComicPress file convention requires that each comic is its own date., do not have comics uploaded on the same date.  While Comic Easel does not require each comic to have its own date, the Import does.  There will be other methods of importing made in the future that this will not be an issue.','comiceasel'); ?><br />
+<cite>*1</cite> - <?php esc_html_e('eg, ComicPress style filenames, if Date Format is: Y-m-d and Date Mask is {DATE}*.* the filename would be (as example if image is a .jpg):','comiceasel'); ?> <strong><?php esc_html_e('2012-01-01-title-of-comic.jpg','comiceasel'); ?></strong><br />
+<cite>*2</cite> - <?php esc_html_e('ComicPress file convention requires that each comic is its own date., do not have comics uploaded on the same date.  While Comic Easel does not require each comic to have its own date, the Import does.  There will be other methods of importing made in the future that this will not be an issue.','comiceasel'); ?><br />
 </p>
 <br />
 <?php
-echo __('Directory to scan:','comiceasel').'&nbsp;<strong>'.ABSPATH.$import_directory.'</strong>'."<br />\r\n";
+echo esc_html__('Directory to scan:','comiceasel').'&nbsp;<strong>'.esc_html(ABSPATH.$import_directory).'</strong>'."<br />\r\n";
 if (count($results = glob(ABSPATH.$import_directory.'/*.*')) > 0) {
-	echo count($results).' '.__('Files found.','comiceasel')."<br />\r\n";
+	echo count($results).' '.esc_html__('Files found.','comiceasel')."<br />\r\n";
 	echo "<hr />\r\n";
 	natcasesort($results);
 	foreach ($results as $filename) {
-		echo '<span style="width:320px;display:inline-block;float:left;">'.basename($filename).'</span>';
+		echo '<span style="width:320px;display:inline-block;float:left;">'.esc_html(basename($filename)).'</span>';
 	}
 } else {
-	echo __('No files found in','comiceasel').'&nbsp;'.ABSPATH.$import_directory;
+	echo esc_html__('No files found in','comiceasel').'&nbsp;'.esc_html(ABSPATH.$import_directory);
 }

--- a/functions/admin-meta.php
+++ b/functions/admin-meta.php
@@ -114,7 +114,7 @@ function ceo_chapters_sortable_columns( $columns ) {
 function ceo_chapters_add_column_value($empty, $custom_column, $term_id) {
 	switch ($custom_column) {
 		case 'id':
-			echo $term_id;
+			echo esc_html($term_id);
 			break;
 		case 'menu_order':
 			$taxonomy = 'chapters';
@@ -190,7 +190,7 @@ function ceo_manage_comic_columns($column_name, $id) {
 	case 'comicimages':
 			$post = get_post($id);
 			$comicthumb = ceo_display_comic_thumbnail('thumbnail', $post, array(120,0)); 
-			if (!$comicthumb) { echo __('No thumbnail Found.','comiceasel'); } else {
+			if (!$comicthumb) { echo esc_html__('No thumbnail Found.','comiceasel'); } else {
 				echo $comicthumb;
 			}
 		break;
@@ -211,7 +211,8 @@ function ceo_filter_restrict_manage_posts() {
 			foreach ( $filters as $tax_slug ) {
 				$tax_obj = get_taxonomy( $tax_slug );
 				wp_dropdown_categories( array(
-					'show_option_all' => __('Show All '.$tax_obj->label ),
+					/* translators: %s: taxonomy label, e.g. "Chapters". */
+					'show_option_all' => sprintf(__('Show All %s', 'comiceasel'), $tax_obj->label),
 					'taxonomy' 	  => $tax_slug,
 					'name' 		  => $tax_obj->name,
 					'orderby' 	  => 'name',
@@ -266,28 +267,28 @@ function ceo_edit_toggles_in_post($post) {
 ?>
 <table class="widefat">
 	<tr>
-		<th scope="row"><label for="comic-gallery"><?php _e('Multi-Comic Support?','comiceasel'); ?></label></th>
+		<th scope="row"><label for="comic-gallery"><?php esc_html_e('Multi-Comic Support?','comiceasel'); ?></label></th>
 		<td>
 			<input id="comic-gallery" name="comic-gallery" type="checkbox" value="1" <?php checked(1, get_post_meta( $post->ID, 'comic-gallery', true )); ?> />
 		</td>
 	</tr>
 	<tr>
 		<th scope="row">
-			<label for="comic-gallery-full"><?php _e('Display the comics as full sized?','comiceasel'); ?></label>
-			<span style="font-size: 9px;"><?php _e('Not checking this will use the gallery thumbnail view, if multi-comic is enabled.','comiceasel'); ?></span>
+			<label for="comic-gallery-full"><?php esc_html_e('Display the comics as full sized?','comiceasel'); ?></label>
+			<span style="font-size: 9px;"><?php esc_html_e('Not checking this will use the gallery thumbnail view, if multi-comic is enabled.','comiceasel'); ?></span>
 		</th>
 		<td>
 			<input id="comic-gallery-full" name="comic-gallery-full" type="checkbox" value="1" <?php checked(1, get_post_meta( $post->ID, 'comic-gallery-full', true )); ?> />
 		</td>
 	</tr>
 	<tr>
-		<th scope="row"><label for="comic-gallery-jquery"><?php _e('Use the jQuery page flipper?','comiceasel'); ?></label></th>
+		<th scope="row"><label for="comic-gallery-jquery"><?php esc_html_e('Use the jQuery page flipper?','comiceasel'); ?></label></th>
 		<td>
 			<input id="comic-gallery-jquery" name="comic-gallery-jquery" type="checkbox" value="1" <?php checked(1, get_post_meta( $post->ID, 'comic-gallery-jquery', true )); ?> />
 		</td>
 	</tr>
 	<tr>
-		<th scope="row"><label for="comic-gallery-columns"><?php _e('If not full sized, how many gallery rows to use?','comiceasel'); ?></label></th>
+		<th scope="row"><label for="comic-gallery-columns"><?php esc_html_e('If not full sized, how many gallery rows to use?','comiceasel'); ?></label></th>
 		<td style="width: 30%">
 			<?php
 				$column_count = get_post_meta( $post->ID, 'comic-gallery-columns', true );
@@ -297,25 +298,25 @@ function ceo_edit_toggles_in_post($post) {
 		</td>
 	</tr>
 	<tr>
-		<th scope="row"><label for="comic-open-lightbox"><?php _e('Open comic up with Lightbox?','comiceasel'); ?></label></th>
+		<th scope="row"><label for="comic-open-lightbox"><?php esc_html_e('Open comic up with Lightbox?','comiceasel'); ?></label></th>
 		<td>
 			<input id="comic-open-lightbox" name="comic-open-lightbox" type="checkbox" value="1" <?php checked(1, get_post_meta( $post->ID, 'comic-open-lightbox', true )); ?> />
 		</td>
 	</tr>
 	<tr>
-		<th scope="row"><label for="comic-has-map"><?php _e('*Comic has Map?','comiceasel'); ?></label></th>
+		<th scope="row"><label for="comic-has-map"><?php esc_html_e('*Comic has Map?','comiceasel'); ?></label></th>
 		<td>
 			<input id="comic-has-map" name="comic-has-map" type="checkbox" value="1" <?php checked(1, get_post_meta( $post->ID, 'comic-has-map', true )); ?> />
 		</td>
 	</tr>
 	<tr>
-		<th scope="row"><label for="comic-content-warning"><?php _e('Enable Content Warning?','comiceasel'); ?></label></th>
+		<th scope="row"><label for="comic-content-warning"><?php esc_html_e('Enable Content Warning?','comiceasel'); ?></label></th>
 		<td>
 			<input id="comic-content-warning" name="comic-content-warning" type="checkbox" value="1" <?php checked(1, get_post_meta( $post->ID, 'comic-content-warning', true )); ?> />
 		</td>
 	</tr>	
 </table>
-<em><?php _e('*  usemap="#comicmap" will be added, add the map html to the below html box','comiceasel'); ?></em>
+<em><?php esc_html_e('*  usemap="#comicmap" will be added, add the map html to the below html box','comiceasel'); ?></em>
 <?php
 }
 
@@ -338,7 +339,7 @@ blip.tv, DailyMotion, FunnyOrDie.com, Hulu, Instagram, Qik, Photobucket, Rdio, R
 
 function ceo_edit_linkto_in_post($post) {
 	$linkto_url = get_post_meta($post->ID, 'link-to', true); 
-	_e('Add url here or leave empty to use next comic or default none', 'comiceasel');
+	esc_html_e('Add url here or leave empty to use next comic or default none', 'comiceasel');
 	?>
 	<br />
 	<input id="link-to" name="link-to" type="input" style="width: 80%" value="<?php echo esc_attr(ceo_meta_for_editor($linkto_url)); ?>" /><br />
@@ -348,12 +349,12 @@ function ceo_edit_linkto_in_post($post) {
 function ceo_edit_refer_only_in_post($post) {
 	$refer_only = get_post_meta($post->ID, 'refer-only', true); 
 	$refer_only_msg = get_post_meta($post->ID, 'refer-only-msg', true);
-	_e('Add url here of referring website to make it only visible when coming from that url.', 'comiceasel');
+	esc_html_e('Add url here of referring website to make it only visible when coming from that url.', 'comiceasel');
 	?>
 	<br />
 	<input id="refer-only" name="refer-only" type="input" style="width: 80%" value="<?php echo esc_attr(ceo_meta_for_editor($refer_only)); ?>" /><br />
 	<br />
-	<?php _e("Message to display to users who don't visit from the referring site.",'comiceasel'); ?><br />
+	<?php esc_html_e("Message to display to users who don't visit from the referring site.",'comiceasel'); ?><br />
 	<input id="refer-only-msg" name="refer-only-msg" type="input" style="width: 80%" value="<?php echo esc_attr(ceo_meta_for_editor($refer_only_msg)); ?>" /><br />
 	<?php
 }
@@ -364,7 +365,7 @@ function ceo_edit_hovertext_in_post($post) {
 	if (empty($hovertext)) $hovertext = get_post_meta($post->ID, 'hovertext', true);
 	if (!$hovertext) $hovertext = '';
 ?>
-	<?php _e('The text placed here will appear when you mouse over the comic.','comiceasel'); ?><br />
+	<?php esc_html_e('The text placed here will appear when you mouse over the comic.','comiceasel'); ?><br />
 	<textarea name="comic-hovertext" id="comic-hovertext" class="admin-comic-hovertext" style="width:100%"><?php echo esc_textarea(ceo_meta_for_editor($hovertext)); ?></textarea>
 <?php
 }
@@ -372,7 +373,7 @@ function ceo_edit_hovertext_in_post($post) {
 function ceo_edit_transcript_in_post($post) { 
 	wp_nonce_field( basename( __FILE__ ), 'comic_nonce' );
 ?>
-	<?php _e('The text placed here will appear as the transcript.','comiceasel'); ?><br />
+	<?php esc_html_e('The text placed here will appear as the transcript.','comiceasel'); ?><br />
 	<textarea name="transcript" id="transcript" class="admin-transcript" style="width:100%; height: 100px;"><?php echo esc_textarea(ceo_meta_for_editor(get_post_meta($post->ID, 'transcript', true))); ?></textarea>
 <?php
 }
@@ -380,7 +381,7 @@ function ceo_edit_transcript_in_post($post) {
 function ceo_edit_html_above_comic($post) { 
 	wp_nonce_field( basename( __FILE__ ), 'comic_nonce' );
 ?>
-	<?php _e('The html placed here will appear above the comic.','comiceasel'); ?><br />
+	<?php esc_html_e('The html placed here will appear above the comic.','comiceasel'); ?><br />
 	<textarea name="comic-html-above" id="comic-html-above" class="admin-comic-html-above" style="width:100%"><?php echo esc_textarea(ceo_meta_for_editor(get_post_meta( $post->ID, 'comic-html-above', true ))); ?></textarea>
 <?php
 }
@@ -388,7 +389,7 @@ function ceo_edit_html_above_comic($post) {
 function ceo_edit_html_below_comic($post) { 
 	wp_nonce_field( basename( __FILE__ ), 'comic_nonce' );
 ?>
-	<?php _e('The html placed here will appear below the comic.','comiceasel'); ?><br />
+	<?php esc_html_e('The html placed here will appear below the comic.','comiceasel'); ?><br />
 	<textarea name="comic-html-below" id="comic-html-below" class="admin-comic-html-below" style="width:100%"><?php echo esc_textarea(ceo_meta_for_editor(get_post_meta( $post->ID, 'comic-html-below', true ))); ?></textarea>
 <?php
 }
@@ -411,19 +412,19 @@ function ceo_edit_buycomic_in_post($post) {
 		<tr>
 		<?php if (ceo_pluginfo('buy_comic_sell_print')) { ?>
 			<td align="left" valign="top" width="50%">
-				<?php _e('Print Cost','comiceasel'); ?> <input name="buy_print_amount" id="buy_print_amount" type="text" size="5" value="<?php echo esc_attr(ceo_meta_for_editor($currentbuyprintamount)) ?>" />  <br />
-				<input name="buyprint-status" id="buyprint-available" type="radio" value="<?php _e('Available','comiceasel'); ?>" <?php if (($currentbuyprintoption == __('Available','comiceasel')) || empty($currentbuyprintoption)) { echo " checked"; } ?> /> <label for="buyprint-available"><?php _e('Available','comiceasel'); ?></label><br />
-				<input name="buyprint-status" id="buyprint-sold" type="radio" value="<?php _e('Sold','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Sold','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-sold">Sold</label><br />
-				<input name="buyprint-status" id="buyprint-outofstock" type="radio" value="<?php _e('Out of Stock','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Out of Stock','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-outofstock"><?php _e('Out of Stock','comiceasel'); ?></label><br />
-				<input name="buyprint-status" id="buyprint-notavail" type="radio" value="<?php _e('Not Available','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Not Available','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-notavail"><?php _e('Not Available','comiceasel'); ?></label><br />
+				<?php esc_html_e('Print Cost','comiceasel'); ?> <input name="buy_print_amount" id="buy_print_amount" type="text" size="5" value="<?php echo esc_attr(ceo_meta_for_editor($currentbuyprintamount)) ?>" />  <br />
+				<input name="buyprint-status" id="buyprint-available" type="radio" value="<?php esc_attr_e('Available','comiceasel'); ?>" <?php if (($currentbuyprintoption == __('Available','comiceasel')) || empty($currentbuyprintoption)) { echo " checked"; } ?> /> <label for="buyprint-available"><?php esc_html_e('Available','comiceasel'); ?></label><br />
+				<input name="buyprint-status" id="buyprint-sold" type="radio" value="<?php esc_attr_e('Sold','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Sold','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-sold">Sold</label><br />
+				<input name="buyprint-status" id="buyprint-outofstock" type="radio" value="<?php esc_attr_e('Out of Stock','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Out of Stock','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-outofstock"><?php esc_html_e('Out of Stock','comiceasel'); ?></label><br />
+				<input name="buyprint-status" id="buyprint-notavail" type="radio" value="<?php esc_attr_e('Not Available','comiceasel'); ?>" <?php if ($currentbuyprintoption == __('Not Available','comiceasel')) { echo " checked"; } ?> /> <label for="buyprint-notavail"><?php esc_html_e('Not Available','comiceasel'); ?></label><br />
 			</td>
 		<?php }
 			if (ceo_pluginfo('buy_comic_sell_original')) { ?>
 			<td align="left" valign="top">
-				<?php _e('Original Cost','comiceasel'); ?> <input name="buy_print_orig_amount" id="buy_print_orig_amount" size="5" type="text" value="<?php echo esc_attr(ceo_meta_for_editor($currentbuyorigamount)); ?>" /><br />
-				<input name="buyorig-status" id="buyorig-available" type="radio" value="<?php _e('Available','comiceasel'); ?>" <?php if (($currentbuyorigoption == __('Available','comiceasel')) || empty($currentbuyorigoption)) { echo " checked"; } ?> /> <label for="buyorig-available"><?php _e('Available','comiceasel'); ?></label><br />
-				<input name="buyorig-status" id="buyorig-sold" type="radio" value="<?php _e('Sold','comiceasel'); ?>" <?php if ($currentbuyorigoption == __('Sold','comiceasel')) { echo " checked"; } ?> /> <label for="buyorig-sold"><?php _e('Sold','comiceasel'); ?></label><br />
-				<input name="buyorig-status" id="buyorig-notavail" type="radio" value="<?php _e('Not Available','comiceasel'); ?>" <?php if ($currentbuyorigoption == __('Not Available','comiceasel')) { echo " checked"; } ?> /> <label for="buyorig-notavail"><?php _e('Not Available','comiceasel'); ?></label><br />
+				<?php esc_html_e('Original Cost','comiceasel'); ?> <input name="buy_print_orig_amount" id="buy_print_orig_amount" size="5" type="text" value="<?php echo esc_attr(ceo_meta_for_editor($currentbuyorigamount)); ?>" /><br />
+				<input name="buyorig-status" id="buyorig-available" type="radio" value="<?php esc_attr_e('Available','comiceasel'); ?>" <?php if (($currentbuyorigoption == __('Available','comiceasel')) || empty($currentbuyorigoption)) { echo " checked"; } ?> /> <label for="buyorig-available"><?php esc_html_e('Available','comiceasel'); ?></label><br />
+				<input name="buyorig-status" id="buyorig-sold" type="radio" value="<?php esc_attr_e('Sold','comiceasel'); ?>" <?php if ($currentbuyorigoption == __('Sold','comiceasel')) { echo " checked"; } ?> /> <label for="buyorig-sold"><?php esc_html_e('Sold','comiceasel'); ?></label><br />
+				<input name="buyorig-status" id="buyorig-notavail" type="radio" value="<?php esc_attr_e('Not Available','comiceasel'); ?>" <?php if ($currentbuyorigoption == __('Not Available','comiceasel')) { echo " checked"; } ?> /> <label for="buyorig-notavail"><?php esc_html_e('Not Available','comiceasel'); ?></label><br />
 			</td>
 		<?php } ?>
 		</tr>
@@ -443,14 +444,14 @@ function ceo_edit_taxonomy_archive_overwrite() {
 	$terms = get_terms($taxonomies);
 	if (!is_wp_error($terms) && !empty($terms)) { ?>
 		<select name="location-overwrite" id="location-overwrite">
-			<option class="level-0" value="" <?php if ($current_selected == 'none' || empty($current_selected)) { ?>selected="selected"<?php } ?>><?php echo __('Do Not Use', 'comiceasel'); ?></option>
+			<option class="level-0" value="" <?php if ($current_selected == 'none' || empty($current_selected)) { ?>selected="selected"<?php } ?>><?php echo esc_html__('Do Not Use', 'comiceasel'); ?></option>
 	<?php
 		foreach ($terms as $term) { ?>
 			<option class="level-0" value="<?php echo esc_attr($term->slug); ?>" <?php if ($current_selected == $term->slug) { ?>selected="selected"<?php } ?>><?php echo esc_html($term->name); ?></option>
 	<?php } ?>
 		</select>
 <?php		
-	} else _e('There are no characters or locations yet.', 'comiceasel');
+	} else esc_html_e('There are no characters or locations yet.', 'comiceasel');
 }
 
 
@@ -506,8 +507,8 @@ function ceo_test_for_errors() {
 	global $post; 
 	if (is_numeric($post->post_name)) { ?>
 	<div class="error">
-		<h2><?php _e('Problem.','comiceasel'); ?></h2>
-		<?php echo __('The slug for this comic post "','comiceasel').$post->post_name.__('" is numerical.  It needs to have a letter or character added to it to not be recognized as a date.  P.S. Cannot use these characters: !&#@','comiceasel'); ?><br />
+		<h2><?php esc_html_e('Problem.','comiceasel'); ?></h2>
+		<?php echo esc_html__('The slug for this comic post "','comiceasel').esc_html($post->post_name).esc_html__('" is numerical.  It needs to have a letter or character added to it to not be recognized as a date.  P.S. Cannot use these characters: !&#@','comiceasel'); ?><br />
 	</div>
 <?php }
 }

--- a/functions/injections.php
+++ b/functions/injections.php
@@ -34,7 +34,7 @@ function ceo_version_meta() {
 function ceo_display_edit_link() {
 	global $post;
 	if (($post->post_type == 'comic') && current_user_can('edit_post', $post->ID)) {
-		echo '<a href="'.get_edit_post_link().'">'.__('Edit Comic.','comiceasel')."</a><br />\r\n";
+		echo '<a href="'.esc_url(get_edit_post_link()).'">'.esc_html__('Edit Comic.','comiceasel')."</a><br />\r\n";
 	}
 }
 
@@ -131,11 +131,11 @@ function ceo_display_comic_navigation() {
 				$bpsep = '?';
 			}
 		?>
-		<td class="comic-nav"><a href="<?php echo esc_url(ceo_pluginfo('buy_comic_url').$bpsep.'id='.$post->ID); ?>" class="comic-nav-base comic-nav-buycomic" title="Buy Comic"><?php _e('Buy!','comiceasel'); ?></a></td>
+		<td class="comic-nav"><a href="<?php echo esc_url(ceo_pluginfo('buy_comic_url').$bpsep.'id='.$post->ID); ?>" class="comic-nav-base comic-nav-buycomic" title="Buy Comic"><?php esc_html_e('Buy!','comiceasel'); ?></a></td>
 <?php }
 if (ceo_pluginfo('enable_comment_nav') && !wp_is_mobile()) { 
 			$commentscount = get_comments_number(); ?>
-			<td class="comic-nav"><a href="<?php comments_link(); ?>" class="comic-nav-comments" title="<?php echo ceo_title_for_attribute($post->ID); ?>"><span class="comic-nav-comment-count"><?php echo esc_html(sprintf( _n( 'Comment(%d)', 'Comments(%d)', $commentscount, 'comiceasel' ), $commentscount )); ?></span></a></td>
+			<td class="comic-nav"><a href="<?php comments_link(); ?>" class="comic-nav-comments" title="<?php echo ceo_title_for_attribute($post->ID); ?>"><span class="comic-nav-comment-count"><?php /* translators: %d: number of comments on the comic. */ echo esc_html(sprintf( _n( 'Comment(%d)', 'Comments(%d)', $commentscount, 'comiceasel' ), $commentscount )); ?></span></a></td>
 <?php } 
 	if (ceo_pluginfo('enable_random_nav') && !wp_is_mobile()) { 
 		$stay = '';

--- a/functions/library.php
+++ b/functions/library.php
@@ -28,7 +28,7 @@ function ceo_get_sidebar($location = '') {
 	if (file_exists(get_stylesheet_directory().'/sidebar-'.$location.'.php')) {
 		get_sidebar($location);
 	} elseif (is_active_sidebar('ceo-sidebar-'.$location)) { ?>
-		<div id="sidebar-<?php echo $location; ?>" class="sidebar">
+		<div id="sidebar-<?php echo esc_attr($location); ?>" class="sidebar">
 			<?php dynamic_sidebar('ceo-sidebar-'.$location); ?>
 		</div>
 	<?php }

--- a/functions/navigation.php
+++ b/functions/navigation.php
@@ -207,12 +207,13 @@ function ceo_get_adjacent_chapter($prev = false) {
 	
 	if (!$find_order) return false;
 	$args = array(
+			'taxonomy' => 'chapters',
 			'orderby' => 'menu_order',
 			'order' => 'DESC',
 			'hide_empty' => 1,
 			'menu_order' => $find_order
 			);
-	$all_chapters = get_terms( 'chapters', $args );
+	$all_chapters = get_terms( $args );
 	if (!is_null($all_chapters)) {
 		foreach($all_chapters as $chapter) {
 			if ((int)$chapter->menu_order == $find_order) return $chapter;

--- a/functions/shortcodes.php
+++ b/functions/shortcodes.php
@@ -105,10 +105,14 @@ function ceo_cast_page( $atts, $content = '' ) {
 		return $cast_output;
 	}
 	if (empty($character)) {
-		if ($limit) {
-			$args = 'orderby=count&order='.$order.'&hide_empty=1&number='.$limit;
-		} else $args = 'orderby=count&order='.$order.'&hide_empty=1';
-		$characters = get_terms( 'characters', $args );
+		$args = array(
+			'taxonomy' => 'characters',
+			'orderby' => 'count',
+			'order' => $order,
+			'hide_empty' => 1
+			);
+		if ($limit) $args['number'] = $limit;
+		$characters = get_terms( $args );
 		if (is_array($characters)) {
 			$cast_output .= '<table class="cast-wrapper">'."\r\n";
 			foreach ($characters as $character) {
@@ -207,12 +211,13 @@ function ceo_get_terms_orderby($orderby, $args) {
 function ceo_archive_list_all($order = 'ASC', $thumbnail = 0) {
 	$output = '';
 	$main_args = array(
+			'taxonomy' => 'chapters',
 			'hide_empty' => true,
 			'order' => $order,
 			'orderby' => 'menu_order',
 			'hierarchical' => 1
 			);
-	$all_chapters = get_terms('chapters', $main_args);
+	$all_chapters = get_terms($main_args);
 	if (is_null($all_chapters)) { echo 'There are no chapters available.'; return; }
 	$output = '';
 	foreach ($all_chapters as $chapter) {
@@ -254,13 +259,14 @@ function ceo_archive_list_series($thumbnail = 0) {
 	$output = '';
 	$archive_count = 0;
 	$args = array(
+			'taxonomy' => 'chapters',
 			'pad_counts' => 0,
 			'order' => 'ASC',
 			'hide_empty' => false,
 			'parent' => 0,
 			'orderby' => 'menu_order'
 			);
-	$parent_chapters = get_terms('chapters', $args);
+	$parent_chapters = get_terms($args);
 	if (is_array($parent_chapters)) {
 		foreach($parent_chapters as $parent_chapter) {
 			$output .= '<h2 class="comic-archive-series-title">'.wp_kses_post($parent_chapter->name).'</h2>';
@@ -306,12 +312,13 @@ function ceo_archive_list_by_chapter_thumbnails($order = 'ASC', $showtitle = fal
 	$output = '';
 	$archive_count = 0;
 	$args = array(
+			'taxonomy' => 'chapters',
 			'pad_counts' => 0,
 			'order' => $order,
 			'hide_empty' => 1,
 			'orderby' => 'menu_order'
 			);
-	$chapters = get_terms('chapters', $args);
+	$chapters = get_terms($args);
 	if (is_array($chapters) && !is_wp_error($chapters)) {
 		$output .= '<div class="comic-archive-list-4">';
 		foreach($chapters as $chapter) {

--- a/options/archive.php
+++ b/options/archive.php
@@ -5,41 +5,41 @@
 	<?php wp_nonce_field('update-options') ?>
 
 		<div class="comiceasel-options">
-			<div style='color: #b00;font-size: 16px;text-align:center;background-color: #efefef;padding: 5px;border: solid 2px #000;font-weight: 700;'><?php _e('IMPORTANT - If you change any of the settings on this page from the default, go to settings -> permalink and click SAVE so that the permalink structure can be recognized by WordPress','comiceasel'); ?></div>
+			<div style='color: #b00;font-size: 16px;text-align:center;background-color: #efefef;padding: 5px;border: solid 2px #000;font-weight: 700;'><?php esc_html_e('IMPORTANT - If you change any of the settings on this page from the default, go to settings -> permalink and click SAVE so that the permalink structure can be recognized by WordPress','comiceasel'); ?></div>
 			<br />
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Archive Options','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Archive Options','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr class="alternate">
-					<th scope="row"><label for="include_comics_in_blog_archive"><?php _e('Include the comics in the blog archive?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="include_comics_in_blog_archive"><?php esc_html_e('Include the comics in the blog archive?','comiceasel'); ?></label></th>
 					<td>
 						<input id="include_comics_in_blog_archive" name="include_comics_in_blog_archive" type="checkbox" value="1" <?php checked(true, $ceo_options['include_comics_in_blog_archive']); ?> />
 					</td>
 					<td>
-						<?php _e('When this is enabled, when you search through the year/date/month and other archiving WordPress functions, the comic will appear with the regular blog posts.  This feature automatically works for all tags already.','comiceasel'); ?>
+						<?php esc_html_e('When this is enabled, when you search through the year/date/month and other archiving WordPress functions, the comic will appear with the regular blog posts.  This feature automatically works for all tags already.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
 					<?php if (!isset($ceo_options['disable_cal_rewrite_rules'])) $ceo_options['disable_cal_rewrite_rules'] = false; ?>
-					<th scope="row"><label for="disable_cal_rewrite_rules"><?php _e('Disable the the rewrite rules so numerical slugs do not get turned into dates?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_cal_rewrite_rules"><?php esc_html_e('Disable the the rewrite rules so numerical slugs do not get turned into dates?','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_cal_rewrite_rules" name="disable_cal_rewrite_rules" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_cal_rewrite_rules']); ?> />
 					</td>
 					<td>
-						<?php _e('This option disables the url line from interpreting numerical numbers as dates. ex. /comic/2014/','comiceasel'); ?>
+						<?php esc_html_e('This option disables the url line from interpreting numerical numbers as dates. ex. /comic/2014/','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
 					<?php if (!isset($ceo_options['enable_chapter_in_url'])) $ceo_options['enable_chapter_in_url'] = false; ?>
-					<th scope="row"><label for="enable_chapter_in_url"><?php _e('Allow the URL to also denote the chapter?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_chapter_in_url"><?php esc_html_e('Allow the URL to also denote the chapter?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_chapter_in_url" name="enable_chapter_in_url" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_chapter_in_url']); ?> />
 					</td>
 					<td>
-						<?php _e('Allows the chapter that the comic is in to show up in the URL of the comic. ex: /comic/chapter-slug/postname/','comiceasel'); ?>
+						<?php esc_html_e('Allows the chapter that the comic is in to show up in the URL of the comic. ex: /comic/chapter-slug/postname/','comiceasel'); ?>
 					</td>
 				</tr>
 			</table>
@@ -47,57 +47,57 @@
 			<table class="widefat">
 			<thead>
 				<tr>
-					<th colspan="3"><?php _e('Comic Post Type','comiceasel'); ?></th>
+					<th colspan="3"><?php esc_html_e('Comic Post Type','comiceasel'); ?></th>
 				</tr>
 			</thead>
 				<tr class="alternate">
 					<?php if (empty($ceo_options['custom_post_type_slug_name'])) $ceo_options['custom_post_type_slug_name'] = 'comic'; ?>
-					<th scope="row"><label for="custom_post_type_slug_name"><?php _e('Custom Post Type slug name?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="custom_post_type_slug_name"><?php esc_html_e('Custom Post Type slug name?','comiceasel'); ?></label></th>
 					<td>
 						<input id="custom_post_type_slug_name" name="custom_post_type_slug_name" type="text" value="<?php echo esc_attr($ceo_options['custom_post_type_slug_name']); ?>" /><br />
 <?php 
 $check_term = term_exists($ceo_options['custom_post_type_slug_name']);
 if ($check_term) { ?>
-	<span style="font-weight: 700; color: #f00;"><?php _e('This slug already exists and will cause problems.  Change it.','comiceasel'); ?></span>
+	<span style="font-weight: 700; color: #f00;"><?php esc_html_e('This slug already exists and will cause problems.  Change it.','comiceasel'); ?></span>
 <?php if ($ceo_options['custom_post_type_slug_name'] == 'comic') { ?>
-	<br /><?php _e('This is the default custom post type slug - which is already in use on your system.  Sometimes people have the chapter name as this slug, that needs to be changed if you want to use the default.','comiceasel'); ?>
+	<br /><?php esc_html_e('This is the default custom post type slug - which is already in use on your system.  Sometimes people have the chapter name as this slug, that needs to be changed if you want to use the default.','comiceasel'); ?>
 	<?php } 
 }
 ?>
 					</td>
 					<td>
-						<?php _e('Default: "comic" changing this will modify the permalink name for the /comic/ how it is addressed in the url.  This is a slug name, no slashes or spaces allowed; only alpha characters and a single word.','comiceasel'); ?><br />
+						<?php esc_html_e('Default: "comic" changing this will modify the permalink name for the /comic/ how it is addressed in the url.  This is a slug name, no slashes or spaces allowed; only alpha characters and a single word.','comiceasel'); ?><br />
 						<br />
 					</td>
 				</tr>
 				<tr>
 					<?php if (empty($ceo_options['chapter_type_slug_name'])) $ceo_options['chapter_type_slug_name'] = 'comic'; ?>
-					<th scope="row"><label for="chapter_type_slug_name"><?php _e('Chapter Type slug name?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="chapter_type_slug_name"><?php esc_html_e('Chapter Type slug name?','comiceasel'); ?></label></th>
 					<td>
 						<input id="chapter_type_slug_name" name="chapter_type_slug_name" type="text" value="<?php echo esc_attr($ceo_options['chapter_type_slug_name']); ?>" /><br />
 <?php 
 $check_term = term_exists($ceo_options['chapter_type_slug_name']);
 if ($check_term) { ?>
-	<span style="font-weight: 700; color: #f00;"><?php _e('This slug already exists and will cause problems.  Change it.','comiceasel'); ?></span>
+	<span style="font-weight: 700; color: #f00;"><?php esc_html_e('This slug already exists and will cause problems.  Change it.','comiceasel'); ?></span>
 <?php if ($ceo_options['chapter_type_slug_name'] == 'chapter') { ?>
-	<br /><?php _e('This is the default chapter slug - which is already in use on your system.','comiceasel'); ?>
+	<br /><?php esc_html_e('This is the default chapter slug - which is already in use on your system.','comiceasel'); ?>
 	<?php } 
 }
 ?>
 					</td>
 					<td>
-						<?php _e('Default: "chapter" changing this will modify the permalink name for the /chapter/ how it is addressed in the url.  This is a slug name, no slashes or spaces allowed; only alpha characters and a single word.','comiceasel'); ?><br />
+						<?php esc_html_e('Default: "chapter" changing this will modify the permalink name for the /chapter/ how it is addressed in the url.  This is a slug name, no slashes or spaces allowed; only alpha characters and a single word.','comiceasel'); ?><br />
 						<br />
 					</td>
 				</tr>
 				<tr class="alternate">
 					<?php if (empty($ceo_options['chapter_type_name_plural'])) $ceo_options['chapter_type_name_plural'] = 'chapters'; ?>
-					<th scope="row"><label for="chapter_type_name_plural"><?php _e('Chapter name plural form?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="chapter_type_name_plural"><?php esc_html_e('Chapter name plural form?','comiceasel'); ?></label></th>
 					<td>
 						<input id="chapter_type_name_plural" name="chapter_type_name_plural" type="text" value="<?php echo esc_attr($ceo_options['chapter_type_name_plural']); ?>" /><br />
 					</td>
 					<td>
-						<?php _e('Default: "chapters" changing this will modify the description information of the plural form of what is put as the chapters slug.  For example if you change the chapters slug to "story" this would be "stories" - use lowercase.','comiceasel'); ?><br />
+						<?php esc_html_e('Default: "chapters" changing this will modify the description information of the plural form of what is put as the chapters slug.  For example if you change the chapters slug to "story" this would be "stories" - use lowercase.','comiceasel'); ?><br />
 					</td>
 				</tr>				
 
@@ -109,7 +109,7 @@ if ($check_term) { ?>
 		<div class="ceo-options-save">
 			<div class="ceo-major-publishing-actions">
 				<div class="ceo-publishing-action">
-					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php _e('Save Settings', 'comiceasel'); ?>" />
+					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php esc_attr_e('Save Settings', 'comiceasel'); ?>" />
 					<input type="hidden" name="action" value="ceo_save_archive" />
 				</div>
 				<div class="clear"></div>

--- a/options/buycomic.php
+++ b/options/buycomic.php
@@ -9,16 +9,16 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Buy Comic','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Buy Comic','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_buy_comic"><?php _e('Enable the Buy Comic code?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_buy_comic"><?php esc_html_e('Enable the Buy Comic code?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_buy_comic" name="enable_buy_comic" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_buy_comic']); ?> />
 					</td>
 					<td>
-						<?php _e('Once enabled and saved, more options will appear in the Navigation [tab] for the default navigation and the Navigation Widget.','comiceasel'); ?>
+						<?php esc_html_e('Once enabled and saved, more options will appear in the Navigation [tab] for the default navigation and the Navigation Widget.','comiceasel'); ?>
 					</td>
 				</tr>
 			</table>
@@ -26,17 +26,17 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Buy Comic Info','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Buy Comic Info','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr>
 					<th scope="row" colspan="2">
-						<label for="buy_comic_email"><?php _e('Paypal email address','comiceasel'); ?></label>
+						<label for="buy_comic_email"><?php esc_html_e('Paypal email address','comiceasel'); ?></label>
 						<input type="text" size="25" name="buy_comic_email" id="buy_comic_email" value="<?php echo esc_attr($ceo_options['buy_comic_email']); ?>" />
 					</th>
 					<td>
-						<span style="color: #d54e21;"><?php _e('* This must be correct, you do not want other people getting your money.','comiceasel'); ?></span><br />
-						<?php _e('The Email address you registered with Paypal and that your store is associated with.','comiceasel'); ?>
+						<span style="color: #d54e21;"><?php esc_html_e('* This must be correct, you do not want other people getting your money.','comiceasel'); ?></span><br />
+						<?php esc_html_e('The Email address you registered with Paypal and that your store is associated with.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
@@ -50,53 +50,53 @@
 				</tr>
 				<tr>
 					<th scope="row"colspan="2">
-						<label for="buy_comic_url"><?php _e('FULL URL of where the buy comic shortcode is. (required)','comiceasel'); ?></label>
+						<label for="buy_comic_url"><?php esc_html_e('FULL URL of where the buy comic shortcode is. (required)','comiceasel'); ?></label>
 						<input type="text" size="25" name="buy_comic_url" id="buy_comic_url" value="<?php echo esc_attr($ceo_options['buy_comic_url']); ?>" />
 					</th>
 					<td>
-						<span style="color: #d54e21;"><?php _e('* This must be correct, the form needs some place to go.','comiceasel'); ?></span><br />
-						<?php _e('The FULL URL address to which you associated the buy comic shortcode.','comiceasel'); ?><br />
+						<span style="color: #d54e21;"><?php esc_html_e('* This must be correct, the form needs some place to go.','comiceasel'); ?></span><br />
+						<?php esc_html_e('The FULL URL address to which you associated the buy comic shortcode.','comiceasel'); ?><br />
 						<em>
-							<?php _e('Examples:','comiceasel'); ?>
+							<?php esc_html_e('Examples:','comiceasel'); ?>
 							"http://yourdomain.com/?p=233",
 							"http://yourdomain.com/shop/",
 						</em>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="buy_comic_sell_print"><?php _e('Are you selling prints?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="buy_comic_sell_print"><?php esc_html_e('Are you selling prints?','comiceasel'); ?></label></th>
 					<td>
 						<input id="buy_comic_sell_print" name="buy_comic_sell_print" type="checkbox" value="1" <?php checked(true, $ceo_options['buy_comic_sell_print']); ?> />
 					</td>
 					<td>
-						<?php _e('<strong>NOTE: If you want to add shipping you will have to do that from your profile on paypal.</strong>','comiceasel'); ?>
+						<strong><?php esc_html_e('NOTE: If you want to add shipping you will have to do that from your profile on paypal.','comiceasel'); ?></strong>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="buy_comic_print_amount"><?php _e('Print Cost','comiceasel'); ?></label></th>
+					<th scope="row"><label for="buy_comic_print_amount"><?php esc_html_e('Print Cost','comiceasel'); ?></label></th>
 					<td>
 						<input type="text" size="7" name="buy_comic_print_amount" id="buy_comic_print_amount" value="<?php echo esc_attr($ceo_options['buy_comic_print_amount']); ?>" />
 					</td>
 					<td>
-						<?php _e('How much does a print cost?','comiceasel'); ?>
+						<?php esc_html_e('How much does a print cost?','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="buy_comic_sell_original"><?php _e('Are you selling the original?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="buy_comic_sell_original"><?php esc_html_e('Are you selling the original?','comiceasel'); ?></label></th>
 					<td>
 						<input id="buy_comic_sell_original" name="buy_comic_sell_original" type="checkbox" value="1" <?php checked(true, $ceo_options['buy_comic_sell_original']); ?> />
 					</td>
 					<td>
-						<?php _e('<strong>NOTE: If you want to add shipping you will have to do that from your profile on paypal.</strong>','comiceasel'); ?>
+						<strong><?php esc_html_e('NOTE: If you want to add shipping you will have to do that from your profile on paypal.','comiceasel'); ?></strong>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="buy_comic_orig_amount"><?php _e('Original Cost','comiceasel'); ?></label></th>
+					<th scope="row"><label for="buy_comic_orig_amount"><?php esc_html_e('Original Cost','comiceasel'); ?></label></th>
 					<td>
 						<input type="text" size="7" name="buy_comic_orig_amount" id="buy_comic_orig_amount" value="<?php echo esc_attr($ceo_options['buy_comic_orig_amount']); ?>" />
 					</td>
 					<td>
-						<?php _e('How much are you selling the Original for? (Default price, can set individual prices in each comic post)','comiceasel'); ?>
+						<?php esc_html_e('How much are you selling the Original for? (Default price, can set individual prices in each comic post)','comiceasel'); ?>
 					</td>
 				</tr>
 			</table>
@@ -106,7 +106,7 @@
 		<div class="ceo-options-save">
 			<div class="ceo-major-publishing-actions">
 				<div class="ceo-publishing-action">
-					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php _e('Save Settings', 'comiceasel'); ?>" />
+					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php esc_attr_e('Save Settings', 'comiceasel'); ?>" />
 					<input type="hidden" name="action" value="ceo_save_buycomic" />
 				</div>
 				<div class="clear"></div>

--- a/options/general.php
+++ b/options/general.php
@@ -6,106 +6,106 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Configuration','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Configuration','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr>
-					<th scope="row"><label for="disable_comic_on_home_page"><?php _e('Disable Comic on the Home Page?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_comic_on_home_page"><?php esc_html_e('Disable Comic on the Home Page?','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_comic_on_home_page" name="disable_comic_on_home_page" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_comic_on_home_page']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this will stop the display of the comic and comic area on the home page','comiceasel'); ?>
+						<?php esc_html_e('Checking this will stop the display of the comic and comic area on the home page','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="disable_comic_blog_on_home_page"><?php _e('Disable the Comic Post on the Home Page?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_comic_blog_on_home_page"><?php esc_html_e('Disable the Comic Post on the Home Page?','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_comic_blog_on_home_page" name="disable_comic_blog_on_home_page" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_comic_blog_on_home_page']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this will stop the display of the comic\'s blog on the home page.','comiceasel'); ?>
+						<?php esc_html_e('Checking this will stop the display of the comic\'s blog on the home page.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="enable_comments_on_homepage"><?php _e('Enable comments to appear on the home page for comic posts?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_comments_on_homepage"><?php esc_html_e('Enable comments to appear on the home page for comic posts?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_comments_on_homepage" name="enable_comments_on_homepage" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_comments_on_homepage']); ?> />
 					</td>
 					<td>
-						<?php _e('If the blog loop is disabled and the comic post is enabled on the home page, enabling this will allow the comments for the comic post to appear.','comiceasel'); ?>
+						<?php esc_html_e('If the blog loop is disabled and the comic post is enabled on the home page, enabling this will allow the comments for the comic post to appear.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_comic_sidebar_locations"><?php _e('Enable comic sidebar locations?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_comic_sidebar_locations"><?php esc_html_e('Enable comic sidebar locations?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_comic_sidebar_locations" name="enable_comic_sidebar_locations" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_comic_sidebar_locations']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this option makes 4 new sidebars appear in the appearance - widgets section, above comic, below comic, left of comic and right of comic.','comiceasel'); ?>
+						<?php esc_html_e('Checking this option makes 4 new sidebars appear in the appearance - widgets section, above comic, below comic, left of comic and right of comic.','comiceasel'); ?>
 					</td>
 				</tr>
 <?php /*
 				<tr>
-					<th scope="row"><label for="enable_hoverbox"><?php _e('Enable Hoverbox?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_hoverbox"><?php esc_html_e('Enable Hoverbox?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_hoverbox" name="enable_hoverbox" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_hoverbox']); ?> />
 					</td>
 					<td>
-						<?php _e('Hoverbox is the equivelant of Rascal in ComicPress, mouse-hover over comic leads to a skinnable section that can be customized for viewing the hovertext.','comiceasel'); ?>
+						<?php esc_html_e('Hoverbox is the equivelant of Rascal in ComicPress, mouse-hover over comic leads to a skinnable section that can be customized for viewing the hovertext.','comiceasel'); ?>
 					</td>
 				</tr>
 */				?>
 				<tr class="alternate">
-					<th scope="row"><label for="disable_related_comics"><?php _e('Disable the displaying of related comics?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_related_comics"><?php esc_html_e('Disable the displaying of related comics?','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_related_comics" name="disable_related_comics" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_related_comics']); ?> />
 					</td>
 					<td>
-						<?php _e('If you have a theme that has related comics do_action code installed, this will disable it from displaying.','comiceasel'); ?>
+						<?php esc_html_e('If you have a theme that has related comics do_action code installed, this will disable it from displaying.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="display_first_comic_on_home_page"><?php _e('Show the first comic on the home page?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="display_first_comic_on_home_page"><?php esc_html_e('Show the first comic on the home page?','comiceasel'); ?></label></th>
 					<td>
 						<input id="display_first_comic_on_home_page" name="display_first_comic_on_home_page" type="checkbox" value="1" <?php checked(true, $ceo_options['display_first_comic_on_home_page']); ?> />
 					</td>
 					<td>
-						<?php _e('Enabling this will make it so that the comic on the home page is the first comic.','comiceasel'); ?>
+						<?php esc_html_e('Enabling this will make it so that the comic on the home page is the first comic.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="disable_style_sheet"><?php _e('Disable the default stylesheets. comiceasel.css and navstyle.css','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_style_sheet"><?php esc_html_e('Disable the default stylesheets. comiceasel.css and navstyle.css','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_style_sheet" name="disable_style_sheet" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_style_sheet']); ?> />
 					</td>
 					<td>
-						<?php _e('Checkmarking this will make it so that the default stylesheets do not load, you would need to add those css elements yourself to your style.css','comiceasel'); ?>
+						<?php esc_html_e('Checkmarking this will make it so that the default stylesheets do not load, you would need to add those css elements yourself to your style.css','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="allow_comics_to_have_categories"><?php _e('Allow comics to associate with WordPress categories?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="allow_comics_to_have_categories"><?php esc_html_e('Allow comics to associate with WordPress categories?','comiceasel'); ?></label></th>
 					<td>
 						<input id="allow_comics_to_have_categories" name="allow_comics_to_have_categories" type="checkbox" value="1" <?php checked(true, $ceo_options['allow_comics_to_have_categories']); ?> />
 					</td>
 					<td>
-						<?php _e('For those people who need to allow comics associated with categories as well as chapters. (might cause problems)','comiceasel'); ?>
+						<?php esc_html_e('For those people who need to allow comics associated with categories as well as chapters. (might cause problems)','comiceasel'); ?>
 					</td>
 				</tr>
 <?php if (!defined('CEO_FEATURE_DISABLE_TRANSCRIPT')) { ?>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_transcripts_in_comic_posts"><?php _e('Enable the transcripts to automatically show at the bottom of posts if they exist?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_transcripts_in_comic_posts"><?php esc_html_e('Enable the transcripts to automatically show at the bottom of posts if they exist?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_transcripts_in_comic_posts" name="enable_transcripts_in_comic_posts" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_transcripts_in_comic_posts']); ?> />
 					</td>
 					<td>
-						<?php _e('Enabling this will make transcripts show at the bottom of comic posts, if the comic has a transcript.','comiceasel'); ?>
+						<?php esc_html_e('Enabling this will make transcripts show at the bottom of comic posts, if the comic has a transcript.','comiceasel'); ?>
 					</td>
 				</tr>				
 <?php } ?>
 <?php if (!isset($ceo_options['chapter_on_home'])) $ceo_options['chapter_on_home'] = 0; ?>
 				<tr>
-					<th scope="row"><label for="chapter_on_home"><?php _e('What chapter would you like to display on the home page?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="chapter_on_home"><?php esc_html_e('What chapter would you like to display on the home page?','comiceasel'); ?></label></th>
 					<td>
 <?php $args = array(
 		'show_option_all'	=> 'All Chapters',
@@ -124,16 +124,16 @@ wp_dropdown_categories($args);
 					</td>
 					<td>
 						<?php echo esc_html($ceo_options['chapter_on_home']); ?>
-						<?php _e('Select which chapter or (all) to display on the home page if you have different stories/chapters.','comiceasel'); ?>
+						<?php esc_html_e('Select which chapter or (all) to display on the home page if you have different stories/chapters.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="remove_post_thumbnail"><?php _e('Remove featured image in posts on non-ComicPress themes?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="remove_post_thumbnail"><?php esc_html_e('Remove featured image in posts on non-ComicPress themes?','comiceasel'); ?></label></th>
 					<td>
 						<input id="remove_post_thumbnail" name="remove_post_thumbnail" type="checkbox" value="1" <?php checked(true, $ceo_options['remove_post_thumbnail']); ?> />
 					</td>
 					<td>
-						<?php _e('Try to have Comic Easel automatically remove the featured image in posts on non-ComicPress themes?','comiceasel'); ?>
+						<?php esc_html_e('Try to have Comic Easel automatically remove the featured image in posts on non-ComicPress themes?','comiceasel'); ?>
 					</td>
 				</tr>
 			</table>
@@ -141,81 +141,81 @@ wp_dropdown_categories($args);
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Thumbnail sizes for locations where used.','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Thumbnail sizes for locations where used.','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr class="alternate">
 					<th scope="row">
-						<label for="thumbnail_size_for_rss"><?php _e('Thumbnail size for main RSS Feed','comiceasel'); ?></label>
+						<label for="thumbnail_size_for_rss"><?php esc_html_e('Thumbnail size for main RSS Feed','comiceasel'); ?></label>
 						<select name="thumbnail_size_for_rss" id="thumbnail_size_for_rss">
-							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_rss'],'none'); ?>><?php _e('None', 'comiceasel'); ?></option>
+							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_rss'],'none'); ?>><?php esc_html_e('None', 'comiceasel'); ?></option>
 <?php 
 $thumbnail_sizes = get_intermediate_image_sizes();
 if (!in_array($ceo_options['thumbnail_size_for_rss'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_rss'] != 'none') && ($ceo_options['thumbnail_size_for_rss'] != 'full')) $ceo_options['thumbnail_size_for_rss'] = 'full';
 foreach ($thumbnail_sizes as $size) { ?>
 							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_rss'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
-							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_rss'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>
+							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_rss'],'full'); ?>><?php esc_html_e('Full', 'comiceasel'); ?></option>
 						</select>
 					</th>
 					<td>
-						<?php _e('The thumbnail for the main RSS /feed/','comiceasel'); ?>
+						<?php esc_html_e('The thumbnail for the main RSS /feed/','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
 					<th scope="row">
-						<label for="thumbnail_size_for_direct_rss"><?php _e('Thumbnail size for the direct comic & chapter RSS Feeds','comiceasel'); ?></label>
+						<label for="thumbnail_size_for_direct_rss"><?php esc_html_e('Thumbnail size for the direct comic & chapter RSS Feeds','comiceasel'); ?></label>
 						<select name="thumbnail_size_for_direct_rss" id="thumbnail_size_for_direct_rss">
-							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'],'none'); ?>><?php _e('None', 'comiceasel'); ?></option>
+							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'],'none'); ?>><?php esc_html_e('None', 'comiceasel'); ?></option>
 <?php 
 if (!in_array($ceo_options['thumbnail_size_for_direct_rss'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_direct_rss'] != 'none') && ($ceo_options['thumbnail_size_for_direct_rss'] != 'full')) $ceo_options['thumbnail_size_for_direct_rss'] = 'full';
 foreach ($thumbnail_sizes as $size) { ?>
 							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
-							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>
+							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_direct_rss'],'full'); ?>><?php esc_html_e('Full', 'comiceasel'); ?></option>
 						</select>
 					</th>
 					<td>
-						<?php _e('The thumbnail for the direct comic and chapter RSS /comic/feed/ and /chapter/chapter-slug/feed/','comiceasel'); ?>
+						<?php esc_html_e('The thumbnail for the direct comic and chapter RSS /comic/feed/ and /chapter/chapter-slug/feed/','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
 					<th scope="row">
-						<label for="thumbnail_size_for_archive"><?php _e('Thumbnail size for archive and search','comiceasel'); ?></label>
+						<label for="thumbnail_size_for_archive"><?php esc_html_e('Thumbnail size for archive and search','comiceasel'); ?></label>
 						<select name="thumbnail_size_for_archive" id="thumbnail_size_for_archive">
-							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_archive'],'none'); ?>><?php _e('None', 'comiceasel'); ?></option>
+							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_archive'],'none'); ?>><?php esc_html_e('None', 'comiceasel'); ?></option>
 <?php 
 if (!in_array($ceo_options['thumbnail_size_for_archive'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_archive'] != 'none') && ($ceo_options['thumbnail_size_for_archive'] != 'full')) $ceo_options['thumbnail_size_for_archive'] = 'large';
 foreach ($thumbnail_sizes as $size) { ?>
 							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_archive'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
-							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_archive'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>							
+							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_archive'],'full'); ?>><?php esc_html_e('Full', 'comiceasel'); ?></option>							
 						</select>
 					</th>
 					<td>
-						<?php _e('The thumbnail shown inside posts when viewed in the archive and search functions of WordPress','comiceasel'); ?>
+						<?php esc_html_e('The thumbnail shown inside posts when viewed in the archive and search functions of WordPress','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
 					<th scope="row">
-						<label for="thumbnail_size_for_facebook"><?php _e('Thumbnail size for Facebook images','comiceasel'); ?></label>
+						<label for="thumbnail_size_for_facebook"><?php esc_html_e('Thumbnail size for Facebook images','comiceasel'); ?></label>
 						<select name="thumbnail_size_for_facebook" id="thumbnail_size_for_facebook">
-							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_facebook'],'none'); ?>><?php _e('None', 'comiceasel'); ?></option>
+							<option class="level-0" value="none" <?php selected( $ceo_options['thumbnail_size_for_facebook'],'none'); ?>><?php esc_html_e('None', 'comiceasel'); ?></option>
 <?php 
 if (!in_array($ceo_options['thumbnail_size_for_facebook'], $thumbnail_sizes) && ($ceo_options['thumbnail_size_for_facebook'] != 'none') && ($ceo_options['thumbnail_size_for_facebook'] != 'full')) $ceo_options['thumbnail_size_for_facebook'] = 'large';
 foreach ($thumbnail_sizes as $size) { ?>
 							<option class="level-0" value="<?php echo esc_attr($size); ?>" <?php selected( $ceo_options['thumbnail_size_for_facebook'], $size); ?>><?php echo esc_html(ucfirst($size)); ?></option>
 <?php } ?>
-							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_facebook'],'full'); ?>><?php _e('Full', 'comiceasel'); ?></option>							
+							<option class="level-0" value="full" <?php selected( $ceo_options['thumbnail_size_for_facebook'],'full'); ?>><?php esc_html_e('Full', 'comiceasel'); ?></option>							
 						</select>
 					</th>
 					<td>
-						<?php _e('Comic Easel adds an og:image to the head section of the site.  This is the size of the image that is used for the image that facebook recognizes.  If you are having issues where the image is not the one you want, flip this.','comiceasel'); ?>
+						<?php esc_html_e('Comic Easel adds an og:image to the head section of the site.  This is the size of the image that is used for the image that facebook recognizes.  If you are having issues where the image is not the one you want, flip this.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
 					<td colspan="12">
-						<i><?php _e('NOTE: Edit a post, click update on it for the feeds to refresh with new copies; to see changes.','comiceasel'); ?></i>
+						<i><?php esc_html_e('NOTE: Edit a post, click update on it for the feeds to refresh with new copies; to see changes.','comiceasel'); ?></i>
 					</td>	
 				</tr>
 			</table>
@@ -226,7 +226,7 @@ foreach ($thumbnail_sizes as $size) { ?>
 		<div class="ceo-options-save">
 			<div class="ceo-major-publishing-actions">
 				<div class="ceo-publishing-action">
-					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php _e('Save Settings','comiceasel'); ?>" />
+					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php esc_attr_e('Save Settings','comiceasel'); ?>" />
 					<input type="hidden" name="action" value="ceo_save_general" />
 				</div>
 				<div class="clear"></div>

--- a/options/landing.php
+++ b/options/landing.php
@@ -12,55 +12,55 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Landing Pages', 'comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Landing Pages', 'comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_chapter_landing"><?php _e('Enable chapter landing pages? /chapter/slug-name','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_chapter_landing"><?php esc_html_e('Enable chapter landing pages? /chapter/slug-name','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_chapter_landing" name="enable_chapter_landing" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_chapter_landing']); ?> />
 					</td>
 					<td>
-						<?php _e('When enabled it displays the comic on the archive page for the chapter.','comiceasel'); ?>
+						<?php esc_html_e('When enabled it displays the comic on the archive page for the chapter.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="enable_chapter_landing_first"><?php _e('Display first comic of the chapter on the landing page?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_chapter_landing_first"><?php esc_html_e('Display first comic of the chapter on the landing page?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_chapter_landing_first" name="enable_chapter_landing_first" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_chapter_landing_first']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this will have the landing page/archive for the chapter display the first comic. (unchecked will be latest - default)','comiceasel'); ?>
+						<?php esc_html_e('Checking this will have the landing page/archive for the chapter display the first comic. (unchecked will be latest - default)','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_blog_on_chapter_landing"><?php _e('Enable the blog post for the comic show on the landing page?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_blog_on_chapter_landing"><?php esc_html_e('Enable the blog post for the comic show on the landing page?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_blog_on_chapter_landing" name="enable_blog_on_chapter_landing" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_blog_on_chapter_landing']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this will make the blog post for the comic display on the landing page.','comiceasel'); ?>
+						<?php esc_html_e('Checking this will make the blog post for the comic display on the landing page.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="enable_comments_on_chapter_landing"><?php _e('Enable comments to appear on the landing page under the blog?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_comments_on_chapter_landing"><?php esc_html_e('Enable comments to appear on the landing page under the blog?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_comments_on_chapter_landing" name="enable_comments_on_chapter_landing" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_comments_on_chapter_landing']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this will make the comments appear under the blog post (if blog post is enabled to show) on the landing pages for chapters.','comiceasel'); ?>
+						<?php esc_html_e('Checking this will make the comments appear under the blog post (if blog post is enabled to show) on the landing pages for chapters.','comiceasel'); ?>
 					</td>
 				</tr>
 			</table>
 			<br />
-			<small><?php _e('*Options are specific to the ComicPress theme, this screen will only display if the theme is active.','comiceasel'); ?></small>
+			<small><?php esc_html_e('*Options are specific to the ComicPress theme, this screen will only display if the theme is active.','comiceasel'); ?></small>
 		</div>
 		<br />
 
 		<div class="ceo-options-save">
 			<div class="ceo-major-publishing-actions">
 				<div class="ceo-publishing-action">
-					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php _e('Save Settings','comiceasel'); ?>" />
+					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php esc_attr_e('Save Settings','comiceasel'); ?>" />
 					<input type="hidden" name="action" value="ceo_save_landing" />
 				</div>
 				<div class="clear"></div>

--- a/options/main.php
+++ b/options/main.php
@@ -4,21 +4,21 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Technical Support','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Technical Support','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr>
 					<td>
-						<?php _e('Comic Easel project and support:','comiceasel'); ?>&nbsp;<a href="https://github.com/Frumph/comic-easel">https://github.com/Frumph/comic-easel</a><br />
+						<?php esc_html_e('Comic Easel project and support:','comiceasel'); ?>&nbsp;<a href="https://github.com/Frumph/comic-easel">https://github.com/Frumph/comic-easel</a><br />
 						<br />
-						<?php _e('You can contact me for technical support at any of the following locations:','comiceasel'); ?><br />
-						<em><?php _e('(best chances to reach me at the top going down to the least chance)','comiceasel'); ?></em><br />
+						<?php esc_html_e('You can contact me for technical support at any of the following locations:','comiceasel'); ?><br />
+						<em><?php esc_html_e('(best chances to reach me at the top going down to the least chance)','comiceasel'); ?></em><br />
 						<br />
-						<?php _e('GitHub Issues:', 'comiceasel'); ?> <a href="https://github.com/Frumph/comic-easel/issues">https://github.com/Frumph/comic-easel/issues</a><br />
-						<?php _e('Via Facebook:','comiceasel'); ?> <a href="http://facebook.com/philip.hofer">http://facebook.com/philip.hofer</a><br />
-						<?php _e('WebComics.COM Forums:', 'comiceasel'); ?> <a href="http://webcomics.com/forum/website-design-assistance/">http://webcomics.com/forum/website-design-assistance/</a>  <?php _e('(Subscription only)','comiceasel'); ?><br />
-						<?php _e('WordPress.ORG Forums:', 'comiceasel'); ?> <a href="https://wordpress.org/support/plugin/comic-easel">https://wordpress.org/support/plugin/comic-easel</a> <?php _e('(rarely go here)','comiceasel'); ?><br />
-						<?php _e('On Twitter:', 'comiceasel'); ?> <a href="http://twitter.com/Frumph">http://twitter.com/Frumph</a> <?php _e('(Twitter and I are not friends atm)','comiceasel'); ?> <br />
+						<?php esc_html_e('GitHub Issues:', 'comiceasel'); ?> <a href="https://github.com/Frumph/comic-easel/issues">https://github.com/Frumph/comic-easel/issues</a><br />
+						<?php esc_html_e('Via Facebook:','comiceasel'); ?> <a href="http://facebook.com/philip.hofer">http://facebook.com/philip.hofer</a><br />
+						<?php esc_html_e('WebComics.COM Forums:', 'comiceasel'); ?> <a href="http://webcomics.com/forum/website-design-assistance/">http://webcomics.com/forum/website-design-assistance/</a>  <?php esc_html_e('(Subscription only)','comiceasel'); ?><br />
+						<?php esc_html_e('WordPress.ORG Forums:', 'comiceasel'); ?> <a href="https://wordpress.org/support/plugin/comic-easel">https://wordpress.org/support/plugin/comic-easel</a> <?php esc_html_e('(rarely go here)','comiceasel'); ?><br />
+						<?php esc_html_e('On Twitter:', 'comiceasel'); ?> <a href="http://twitter.com/Frumph">http://twitter.com/Frumph</a> <?php esc_html_e('(Twitter and I are not friends atm)','comiceasel'); ?> <br />
 					</td>
 				</tr>
 			</table>
@@ -26,12 +26,12 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Sponsorship','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Sponsorship','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr>
 					<td>
-						<?php _e('This version of Comic Easel was sponsored by everyone in the WebComic community & my brother who helped me with my gofundme campaign. THANK YOU!  (And Brad Guigar from WebComics.COM)','comiceasel'); ?><br />
+						<?php esc_html_e('This version of Comic Easel was sponsored by everyone in the WebComic community & my brother who helped me with my gofundme campaign. THANK YOU!  (And Brad Guigar from WebComics.COM)','comiceasel'); ?><br />
 					</td>
 				</tr>
 			</table>

--- a/options/navigation.php
+++ b/options/navigation.php
@@ -11,52 +11,52 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Navigation Options','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Navigation Options','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr class="alternate">
-					<th scope="row"><label for="click_comic_next"><?php _e('Clicking the comic goes to next comic?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="click_comic_next"><?php esc_html_e('Clicking the comic goes to next comic?','comiceasel'); ?></label></th>
 					<td>
 						<input id="click_comic_next" name="click_comic_next" type="checkbox" value="1" <?php checked(true, $ceo_options['click_comic_next']); ?> />
 					</td>
 					<td>
-						<?php _e('When this is enabled, when the comic is mouse over and clicked it will go to the next comic in the chapter.','comiceasel'); ?>
+						<?php esc_html_e('When this is enabled, when the comic is mouse over and clicked it will go to the next comic in the chapter.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="disable_mininav"><?php _e('Disable the Menubar Mini-navigation? (if implemented)','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_mininav"><?php esc_html_e('Disable the Menubar Mini-navigation? (if implemented)','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_mininav" name="disable_mininav" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_mininav']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this will disable the mini navigation in the menubar if the theme you are using supports it.','comiceasel'); ?>
+						<?php esc_html_e('Checking this will disable the mini navigation in the menubar if the theme you are using supports it.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_chapter_only_random"><?php _e('Random button (both default and widget) jumps only in the same chapter?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_chapter_only_random"><?php esc_html_e('Random button (both default and widget) jumps only in the same chapter?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_chapter_only_random" name="enable_chapter_only_random" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_chapter_only_random']); ?> />
 					</td>
 					<td>
-						<?php _e('Make the random button only jump to the comics within the same chapter?','comiceasel'); ?>
+						<?php esc_html_e('Make the random button only jump to the comics within the same chapter?','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="enable_prevnext_chapter_traversing"><?php _e('Traverse comic chapters with the previous/next?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_prevnext_chapter_traversing"><?php esc_html_e('Traverse comic chapters with the previous/next?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_prevnext_chapter_traversing" name="enable_prevnext_chapter_traversing" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_prevnext_chapter_traversing']); ?> />
 					</td>
 					<td>
-						<?php _e('If at the first or last comic in a chapter, have the previous and next (in chapter) buttons navigate to the beginning or end of the connected in order chapters?','comiceasel'); ?>
+						<?php esc_html_e('If at the first or last comic in a chapter, have the previous and next (in chapter) buttons navigate to the beginning or end of the connected in order chapters?','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="disable_keynav"><?php _e('Disable Keyboard Navigation?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_keynav"><?php esc_html_e('Disable Keyboard Navigation?','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_keynav" name="disable_keynav" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_keynav']); ?> />
 					</td>
 					<td>
-						<?php _e('When checked this disables the keyboard navigation script from being run.','comiceasel'); ?>
+						<?php esc_html_e('When checked this disables the keyboard navigation script from being run.','comiceasel'); ?>
 					</td>
 				</tr>
 			</table>
@@ -64,7 +64,7 @@
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Navigation Widget','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Navigation Widget','comiceasel'); ?></th>
 					</tr>
 				</thead>
 <?php
@@ -82,7 +82,7 @@ foreach ($dirs_to_search as $gnav_dir) {
 }
 				?>
 				<tr>
-					<th scope="row" colspan="2"><label for="graphic_navigation_directory"><?php _e('Graphic Navigation Set','comiceasel'); ?></label>
+					<th scope="row" colspan="2"><label for="graphic_navigation_directory"><?php esc_html_e('Graphic Navigation Set','comiceasel'); ?></label>
 
 							<select name="graphic_navigation_directory" id="graphic_navigation_directory">
 <?php
@@ -97,7 +97,7 @@ foreach ($gnav_directories as $gnav_dirs) {
 					</th>
 					<td>
 						<?php _e('Choose a directory to get the graphic navigation styling from. To create your own custom graphic navigation menu buttons just create a directory under <i>images/nav/</i> in your child theme and place your image files and navstyle.css file inside of it to determine the style of your navigation display.','comiceasel'); ?>
-						<?php if ($ceo_options['disable_style_sheet']) { echo '<br /><strong>'; _e('The navstyle.css is disable via the option in the general tab of this config section, this will have no effect.','comiceasel'); ?></strong><br /><?php } ?>
+						<?php if ($ceo_options['disable_style_sheet']) { echo '<br /><strong>'; esc_html_e('The navstyle.css is disable via the option in the general tab of this config section, this will have no effect.','comiceasel'); ?></strong><br /><?php } ?>
 					</td>
 				</tr>
 			</table>
@@ -105,88 +105,88 @@ foreach ($gnav_directories as $gnav_dirs) {
 			<table class="widefat">
 				<thead>
 					<tr>
-						<th colspan="3"><?php _e('Default Navigation','comiceasel'); ?></th>
+						<th colspan="3"><?php esc_html_e('Default Navigation','comiceasel'); ?></th>
 					</tr>
 				</thead>
 				<tr class="alternate">
-					<th scope="row"><label for="disable_default_nav"><?php _e('Disable default navigation?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="disable_default_nav"><?php esc_html_e('Disable default navigation?','comiceasel'); ?></label></th>
 					<td>
 						<input id="disable_default_nav" name="disable_default_nav" type="checkbox" value="1" <?php checked(true, $ceo_options['disable_default_nav']); ?> />
 					</td>
 					<td>
-						<?php _e('Checking this will disable the default navigation, you could use and skin the navigation widget.','comiceasel'); ?>
+						<?php esc_html_e('Checking this will disable the default navigation, you could use and skin the navigation widget.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="enable_nav_above_comic"><?php _e('Enable Default Navigation above comic?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_nav_above_comic"><?php esc_html_e('Enable Default Navigation above comic?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_nav_above_comic" name="enable_nav_above_comic" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_nav_above_comic']); ?> />
 					</td>
 					<td>
-						<?php _e('Check this to enable the default navigation to appear above the comic.','comiceasel'); ?>
+						<?php esc_html_e('Check this to enable the default navigation to appear above the comic.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="navigate_only_chapters"><?php _e('Navigate through only the chapters and not all comics?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="navigate_only_chapters"><?php esc_html_e('Navigate through only the chapters and not all comics?','comiceasel'); ?></label></th>
 					<td>
 						<input id="navigate_only_chapters" name="navigate_only_chapters" type="checkbox" value="1" <?php checked(true, $ceo_options['navigate_only_chapters']); ?> />
 					</td>
 					<td>
-						<?php _e('Enabling this make the navigation only navigate through individual chapters with the default navigation.','comiceasel'); ?>
+						<?php esc_html_e('Enabling this make the navigation only navigate through individual chapters with the default navigation.','comiceasel'); ?>
 					</td>
 				</tr>				
 				<tr>
-					<th scope="row"><label for="enable_chapter_nav"><?php _e('Enable the chapter navigation drop down in the comic navigation?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_chapter_nav"><?php esc_html_e('Enable the chapter navigation drop down in the comic navigation?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_chapter_nav" name="enable_chapter_nav" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_chapter_nav']); ?> />
 					</td>
 					<td>
-						<?php _e('When this is enabled, a drop down archive box will appear in the navigation that lets you go to the start of each chapter','comiceasel'); ?>
+						<?php esc_html_e('When this is enabled, a drop down archive box will appear in the navigation that lets you go to the start of each chapter','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="default_nav_bar_chapter_goes_to_archive"><?php _e('Chapter navigation jumps to the archive/landing page?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="default_nav_bar_chapter_goes_to_archive"><?php esc_html_e('Chapter navigation jumps to the archive/landing page?','comiceasel'); ?></label></th>
 					<td>
 						<input id="default_nav_bar_chapter_goes_to_archive" name="default_nav_bar_chapter_goes_to_archive" type="checkbox" value="1" <?php checked(true, $ceo_options['default_nav_bar_chapter_goes_to_archive']); ?> />
 					</td>
 					<td>
-						<?php _e('default goes to first comic in the chapter, this option makes it go to the landing page/archive.','comiceasel'); ?>
+						<?php esc_html_e('default goes to first comic in the chapter, this option makes it go to the landing page/archive.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_comic_nav"><?php _e('Enable the comic navigation for the current chapter drop down in the comic navigation?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_comic_nav"><?php esc_html_e('Enable the comic navigation for the current chapter drop down in the comic navigation?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_comic_nav" name="enable_comic_nav" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_comic_nav']); ?> />
 					</td>
 					<td>
-						<?php _e('When this is enabled, a drop down list box will appear in the navigation that lets you go to the any of the comics of the current chapter','comiceasel'); ?>
+						<?php esc_html_e('When this is enabled, a drop down list box will appear in the navigation that lets you go to the any of the comics of the current chapter','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="enable_random_nav"><?php _e('Enable the random comic link in the comic navigation?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_random_nav"><?php esc_html_e('Enable the random comic link in the comic navigation?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_random_nav" name="enable_random_nav" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_random_nav']); ?> />
 					</td>
 					<td>
-						<?php _e('When this is enabled, a link will appear in the navigation that lets you go to a random comic in all chapters.','comiceasel'); ?>
+						<?php esc_html_e('When this is enabled, a link will appear in the navigation that lets you go to a random comic in all chapters.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr class="alternate">
-					<th scope="row"><label for="enable_comment_nav"><?php _e('Enable the comment link in the comic navigation?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_comment_nav"><?php esc_html_e('Enable the comment link in the comic navigation?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_comment_nav" name="enable_comment_nav" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_comment_nav']); ?> />
 					</td>
 					<td>
-						<?php _e('When this is enabled, a link will appear in the navigation that lets you go to the comments section of the current post, it also shows how many comments there currently are.','comiceasel'); ?>
+						<?php esc_html_e('When this is enabled, a link will appear in the navigation that lets you go to the comments section of the current post, it also shows how many comments there currently are.','comiceasel'); ?>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="enable_embed_nav"><?php _e('Enable the "embed this comic" textarea in the comic navigation?','comiceasel'); ?></label></th>
+					<th scope="row"><label for="enable_embed_nav"><?php esc_html_e('Enable the "embed this comic" textarea in the comic navigation?','comiceasel'); ?></label></th>
 					<td>
 						<input id="enable_embed_nav" name="enable_embed_nav" type="checkbox" value="1" <?php checked(true, $ceo_options['enable_embed_nav']); ?> />
 					</td>
 					<td>
-						<?php _e('When this is enabled, a textarea will appear under the navigation with the href and image link to have users embed this comic on their site.','comiceasel'); ?>
+						<?php esc_html_e('When this is enabled, a textarea will appear under the navigation with the href and image link to have users embed this comic on their site.','comiceasel'); ?>
 					</td>
 				</tr>				
 			</table>
@@ -197,7 +197,7 @@ foreach ($gnav_directories as $gnav_dirs) {
 		<div class="ceo-options-save">
 			<div class="ceo-major-publishing-actions">
 				<div class="ceo-publishing-action">
-					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php _e('Save Settings', 'comiceasel'); ?>" />
+					<input name="ceo_save_config" type="submit" class="button-primary" value="<?php esc_attr_e('Save Settings', 'comiceasel'); ?>" />
 					<input type="hidden" name="action" value="ceo_save_navigation" />
 				</div>
 				<div class="clear"></div>

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -293,6 +293,29 @@ if ( ! function_exists( 'esc_attr__' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $text, $domain = 'default' ) {
+		echo esc_html__( $text, $domain );
+	}
+}
+
+if ( ! function_exists( 'esc_attr_e' ) ) {
+	function esc_attr_e( $text, $domain = 'default' ) {
+		echo esc_attr__( $text, $domain );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	function wp_strip_all_tags( $text, $remove_breaks = false ) {
+		$text = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', (string) $text );
+		$text = strip_tags( $text );
+		if ( $remove_breaks ) {
+			$text = preg_replace( '/[\r\n\t ]+/', ' ', $text );
+		}
+		return trim( $text );
+	}
+}
+
 if ( ! function_exists( 'wp_unslash' ) ) {
 	function wp_unslash( $value ) {
 		return is_array( $value ) ? array_map( 'wp_unslash', $value ) : stripslashes( (string) $value );

--- a/widgets/archive-dropdown.php
+++ b/widgets/archive-dropdown.php
@@ -178,8 +178,8 @@ class ceo_comic_archive_dropdown_widget extends WP_Widget {
 	
 	function update($new_instance, $old_instance) {
 		$instance = $old_instance;
-		$instance['title'] = strip_tags($new_instance['title']);
-		$instance['exclude'] = strip_tags($new_instance['exclude']);
+		$instance['title'] = wp_strip_all_tags($new_instance['title']);
+		$instance['exclude'] = wp_strip_all_tags($new_instance['exclude']);
 		$instance['hide'] = ($new_instance['hide']) ? 1:0;
 		$instance['showcount'] = ($new_instance['showcount']) ? 1:0;
 		$instance['jumptoarchive'] = ($new_instance['jumptoarchive']) ? 1:0;
@@ -196,12 +196,12 @@ class ceo_comic_archive_dropdown_widget extends WP_Widget {
 		$jumptoarchive = ($instance['jumptoarchive']) ? 1:0;
 		$render_as_list = ($instance['render_as_list']) ? 1:0;
 		?>
-		<p><label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:','comiceasel'); ?>&nbsp;<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
-		<p><label for="<?php echo $this->get_field_id('exclude'); ?>"><?php _e('Exclude Chapters (comma seperated):','comiceasel'); ?>&nbsp;<input class="widefat" id="<?php echo $this->get_field_id('exclude'); ?>" name="<?php echo $this->get_field_name('exclude'); ?>" type="text" value="<?php echo esc_attr($exclude); ?>" /></label><br /></p>
-		<p><label for="<?php echo $this->get_field_id('hide'); ?>"><?php _e('Hide empty chapters?','comiceasel'); ?>&nbsp;<input id="<?php echo $this->get_field_id('hide'); ?>" name="<?php echo $this->get_field_name('hide'); ?>" type="checkbox" value="1" <?php checked(1, $hide); ?> /></label></p>
-		<p><label for="<?php echo $this->get_field_id('showcount'); ?>"><?php _e('Show the comic count in parenthesis?','comiceasel'); ?>&nbsp;<input id="<?php echo $this->get_field_id('showcount'); ?>" name="<?php echo $this->get_field_name('showcount'); ?>" type="checkbox" value="1" <?php checked(1, $showcount); ?> /></label></p>
-		<p><label for="<?php echo $this->get_field_id('jumptoarchive'); ?>"><?php _e('Jump to archive and not first page?','comiceasel'); ?>&nbsp;<input id="<?php echo $this->get_field_id('jumptoarchive'); ?>" name="<?php echo $this->get_field_name('jumptoarchive'); ?>" type="checkbox" value="1" <?php checked(1, $jumptoarchive); ?> /></label></p>
-		<p><label for="<?php echo $this->get_field_id('render_as_list'); ?>"><?php _e('Show as a list instead of a dropdown?','comiceasel'); ?>&nbsp;<input id="<?php echo $this->get_field_id('render_as_list'); ?>" name="<?php echo $this->get_field_name('render_as_list'); ?>" type="checkbox" value="1" <?php checked(1, $render_as_list); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_html_e('Title:','comiceasel'); ?>&nbsp;<input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('exclude')); ?>"><?php esc_html_e('Exclude Chapters (comma seperated):','comiceasel'); ?>&nbsp;<input class="widefat" id="<?php echo esc_attr($this->get_field_id('exclude')); ?>" name="<?php echo esc_attr($this->get_field_name('exclude')); ?>" type="text" value="<?php echo esc_attr($exclude); ?>" /></label><br /></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('hide')); ?>"><?php esc_html_e('Hide empty chapters?','comiceasel'); ?>&nbsp;<input id="<?php echo esc_attr($this->get_field_id('hide')); ?>" name="<?php echo esc_attr($this->get_field_name('hide')); ?>" type="checkbox" value="1" <?php checked(1, $hide); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('showcount')); ?>"><?php esc_html_e('Show the comic count in parenthesis?','comiceasel'); ?>&nbsp;<input id="<?php echo esc_attr($this->get_field_id('showcount')); ?>" name="<?php echo esc_attr($this->get_field_name('showcount')); ?>" type="checkbox" value="1" <?php checked(1, $showcount); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('jumptoarchive')); ?>"><?php esc_html_e('Jump to archive and not first page?','comiceasel'); ?>&nbsp;<input id="<?php echo esc_attr($this->get_field_id('jumptoarchive')); ?>" name="<?php echo esc_attr($this->get_field_name('jumptoarchive')); ?>" type="checkbox" value="1" <?php checked(1, $jumptoarchive); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('render_as_list')); ?>"><?php esc_html_e('Show as a list instead of a dropdown?','comiceasel'); ?>&nbsp;<input id="<?php echo esc_attr($this->get_field_id('render_as_list')); ?>" name="<?php echo esc_attr($this->get_field_name('render_as_list')); ?>" type="checkbox" value="1" <?php checked(1, $render_as_list); ?> /></label></p>
 		<?php
 	}
 }

--- a/widgets/casthover.php
+++ b/widgets/casthover.php
@@ -124,9 +124,9 @@ class ceo_casthover_reference_widget extends WP_Widget {
 		if (isset($instance['title'])) {
 			$title = $instance['title'];
 		} else {
-			$title = __( '', 'comiceasel' );
+			$title = '';
 		} 
 		?>
-		<p><label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'comiceasel' ); ?></label><input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" /></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id( 'title' )); ?>"><?php esc_html_e( 'Title:', 'comiceasel' ); ?></label><input class="widefat" id="<?php echo esc_attr($this->get_field_id( 'title' )); ?>" name="<?php echo esc_attr($this->get_field_name( 'title' )); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" /></p>
 	<?php }
 }

--- a/widgets/comic-calendar.php
+++ b/widgets/comic-calendar.php
@@ -280,7 +280,7 @@ class ceo_calendar_widget extends WP_Widget {
 					<?php } ?>
 						<div class="wp-calendar-download-links">
 							<?php if (!empty($small) || !empty($medium) || !empty($large)) { ?>
-								<?php _e('DOWNLOAD','comiceasel'); ?>
+								<?php esc_html_e('DOWNLOAD','comiceasel'); ?>
 								<?php
 								  foreach (array(
 								    'small' => array(__('Download Small', 'comiceasel'), __('S', 'comiceasel')),
@@ -308,7 +308,7 @@ class ceo_calendar_widget extends WP_Widget {
 	function update($new_instance, $old_instance = array()) {
 		$instance = array();
 		foreach (array('thumbnail', 'small', 'medium', 'large', 'link') as $field) {
-			if (isset($new_instance[$field])) {	$instance[$field] = strip_tags($new_instance[$field]); }
+			if (isset($new_instance[$field])) {	$instance[$field] = wp_strip_all_tags($new_instance[$field]); }
 		}
 
 		return $instance;
@@ -317,10 +317,10 @@ class ceo_calendar_widget extends WP_Widget {
 	function form($instance) {
 		$instance = wp_parse_args( (array) $instance, array( 'thumbnail' => '', 'small' => '', 'medium' => '', 'large' => '', 'link' => '') );
 
-		$thumbnail = strip_tags($instance['thumbnail']);
-		$small = strip_tags($instance['small']);
-		$medium = strip_tags($instance['medium']);
-		$large = strip_tags($instance['large']);
+		$thumbnail = wp_strip_all_tags($instance['thumbnail']);
+		$small = wp_strip_all_tags($instance['small']);
+		$medium = wp_strip_all_tags($instance['medium']);
+		$large = wp_strip_all_tags($instance['large']);
 		$link = $instance['link'];
 
 		foreach (array(
@@ -333,10 +333,10 @@ class ceo_calendar_widget extends WP_Widget {
 			unset($after);
 			if (is_array($label)) { extract($label); }
 			?><p>
-				<label for="<?php echo $this->get_field_id($field); ?>"><?php echo esc_html($label) ;?>
+				<label for="<?php echo esc_attr($this->get_field_id($field)); ?>"><?php echo esc_html($label) ;?>
 				<input class="widefat"
-							 id="<?php echo $this->get_field_id($field); ?>"
-							 name="<?php echo $this->get_field_name($field); ?>"
+							 id="<?php echo esc_attr($this->get_field_id($field)); ?>"
+							 name="<?php echo esc_attr($this->get_field_name($field)); ?>"
 							 type="text"
 							 value="<?php echo esc_attr($instance[$field]); ?>" />
 				</label>

--- a/widgets/comic-calendar.php
+++ b/widgets/comic-calendar.php
@@ -128,7 +128,7 @@ function ceo_get_calendar($initial = true, $echo = true, $taxonomy = 'post') {
 	<tr>';
 
 	if ( $previous ) {
-		$calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link($previous->year, $previous->month) . $the_post_type.'" title="' . sprintf(__('View posts for %1$s %2$s','comiceasel'), $wp_locale->get_month($previous->month), date('Y', mktime(0, 0 , 0, $previous->month, 1, $previous->year))) . '">&laquo; ' . $wp_locale->get_month_abbrev($wp_locale->get_month($previous->month)) . '</a></td>';
+		$calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link($previous->year, $previous->month) . $the_post_type.'" title="' . sprintf(/* translators: 1: month name, 2: four-digit year. */ __('View posts for %1$s %2$s','comiceasel'), $wp_locale->get_month($previous->month), date('Y', mktime(0, 0 , 0, $previous->month, 1, $previous->year))) . '">&laquo; ' . $wp_locale->get_month_abbrev($wp_locale->get_month($previous->month)) . '</a></td>';
 	} else {
 		$calendar_output .= "\n\t\t".'<td colspan="3" id="prev" class="pad">&nbsp;</td>';
 	}
@@ -136,7 +136,7 @@ function ceo_get_calendar($initial = true, $echo = true, $taxonomy = 'post') {
 	$calendar_output .= "\n\t\t".'<td class="pad">&nbsp;</td>';
 
 	if ( $next ) {
-		$calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link($next->year, $next->month) . $the_post_type.'" title="' . esc_attr( sprintf(__('View posts for %1$s %2$s','comiceasel'), $wp_locale->get_month($next->month), date('Y', mktime(0, 0 , 0, $next->month, 1, $next->year))) ) . '">' . $wp_locale->get_month_abbrev($wp_locale->get_month($next->month)) . ' &raquo;</a></td>';
+		$calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link($next->year, $next->month) . $the_post_type.'" title="' . esc_attr( sprintf(/* translators: 1: month name, 2: four-digit year. */ __('View posts for %1$s %2$s','comiceasel'), $wp_locale->get_month($next->month), date('Y', mktime(0, 0 , 0, $next->month, 1, $next->year))) ) . '">' . $wp_locale->get_month_abbrev($wp_locale->get_month($next->month)) . ' &raquo;</a></td>';
 	} else {
 		$calendar_output .= "\n\t\t".'<td colspan="3" id="next" class="pad">&nbsp;</td>';
 	}

--- a/widgets/comicblogpost.php
+++ b/widgets/comicblogpost.php
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) exit;
 function ceo_display_comic_small_blog_post($instance) {
 	global $post;
 	if ($instance['showtitle']) { echo '<h3 class="comic-post-widget-title">'.ceo_title_for_html($post->ID)."</h3>\r\n"; }
-	if ($instance['showdate']) { echo "<div class=\"comic-post-widget-date\">".get_the_time(get_option('date_format'))."</div>\r\n"; }
+	if ($instance['showdate']) { echo "<div class=\"comic-post-widget-date\">".esc_html(get_the_time(get_option('date_format')))."</div>\r\n"; }
 	the_content();
 	if ($instance['showcommentlink'] && ($post->comment_status == 'open') && !is_singular()) { ?>
 		<div class="comment-link">
@@ -78,7 +78,7 @@ class ceo_comic_blog_post_widget extends WP_Widget {
 	
 	function update($new_instance, $old_instance) {
 		$instance = $old_instance;
-		$instance['title'] = strip_tags($new_instance['title']);
+		$instance['title'] = wp_strip_all_tags($new_instance['title']);
 		$instance['onlyhome'] = (bool)( $new_instance['onlyhome'] == 1 ? true : false );
 		$instance['showtitle'] = (bool)( $new_instance['showtitle'] == 1 ? true : false );		
 		$instance['showdate'] = (bool)( $new_instance['showdate'] == 1 ? true : false );
@@ -89,19 +89,19 @@ class ceo_comic_blog_post_widget extends WP_Widget {
 	
 	function form($instance) {
 		$instance = wp_parse_args( (array) $instance, array( 'title' => '', 'onlyhome' => false, 'showtitle' => false, 'showdate' => false, 'showcommentlink' => false, 'hidecontent' => false  ) );
-		$title = strip_tags($instance['title']);
+		$title = wp_strip_all_tags($instance['title']);
 		$onlyhome = $instance['onlyhome'];
 		$showtitle = $instance['showtitle'];
 		$showdate = $instance['showdate'];
 		$showcommentlink = $instance['showcommentlink'];
 		$hidecontent = $instance['hidecontent'];
 		?>
-		<p><label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Heading:','comiceasel'); ?><br /><input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
-		<p><label for="<?php echo $this->get_field_id('onlyhome'); ?>"><input id="<?php echo $this->get_field_id('onlyhome'); ?>" name="<?php echo $this->get_field_name('onlyhome'); ?>" type="checkbox" value="1" <?php checked(true, $onlyhome); ?> /> <?php _e('Display only on the home page?','comiceasel'); ?></label></p>
-		<p><label for="<?php echo $this->get_field_id('showtitle'); ?>"><input id="<?php echo $this->get_field_id('showtitle'); ?>" name="<?php echo $this->get_field_name('showtitle'); ?>" type="checkbox" value="1" <?php checked(true, $showtitle); ?> /> <?php _e('Show the title of the post?','comiceasel'); ?></label></p>
-		<p><label for="<?php echo $this->get_field_id('showdate'); ?>"><input id="<?php echo $this->get_field_id('showdate'); ?>" name="<?php echo $this->get_field_name('showdate'); ?>" type="checkbox" value="1" <?php checked(true, $showdate); ?> /> <?php _e('Show the date of the post?','comiceasel'); ?></label></p>
-		<p><label for="<?php echo $this->get_field_id('showcommentlink'); ?>"><input id="<?php echo $this->get_field_id('showcommentlink'); ?>" name="<?php echo $this->get_field_name('showcommentlink'); ?>" type="checkbox" value="1" <?php checked(true, $showcommentlink); ?> /> <?php _e('Show the comment link to the post?','comiceasel'); ?></label></p>
-		<p><label for="<?php echo $this->get_field_id('hidecontent'); ?>"><input id="<?php echo $this->get_field_id('hidecontent'); ?>" name="<?php echo $this->get_field_name('hidecontent'); ?>" type="checkbox" value="1" <?php checked(true, $hidecontent); ?> /> <?php _e('Hide the display of the widget if there is no content?','comiceasel'); ?></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_html_e('Heading:','comiceasel'); ?><br /><input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('onlyhome')); ?>"><input id="<?php echo esc_attr($this->get_field_id('onlyhome')); ?>" name="<?php echo esc_attr($this->get_field_name('onlyhome')); ?>" type="checkbox" value="1" <?php checked(true, $onlyhome); ?> /> <?php esc_html_e('Display only on the home page?','comiceasel'); ?></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('showtitle')); ?>"><input id="<?php echo esc_attr($this->get_field_id('showtitle')); ?>" name="<?php echo esc_attr($this->get_field_name('showtitle')); ?>" type="checkbox" value="1" <?php checked(true, $showtitle); ?> /> <?php esc_html_e('Show the title of the post?','comiceasel'); ?></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('showdate')); ?>"><input id="<?php echo esc_attr($this->get_field_id('showdate')); ?>" name="<?php echo esc_attr($this->get_field_name('showdate')); ?>" type="checkbox" value="1" <?php checked(true, $showdate); ?> /> <?php esc_html_e('Show the date of the post?','comiceasel'); ?></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('showcommentlink')); ?>"><input id="<?php echo esc_attr($this->get_field_id('showcommentlink')); ?>" name="<?php echo esc_attr($this->get_field_name('showcommentlink')); ?>" type="checkbox" value="1" <?php checked(true, $showcommentlink); ?> /> <?php esc_html_e('Show the comment link to the post?','comiceasel'); ?></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('hidecontent')); ?>"><input id="<?php echo esc_attr($this->get_field_id('hidecontent')); ?>" name="<?php echo esc_attr($this->get_field_name('hidecontent')); ?>" type="checkbox" value="1" <?php checked(true, $hidecontent); ?> /> <?php esc_html_e('Hide the display of the widget if there is no content?','comiceasel'); ?></label></p>
 		
 		<?php
 	}

--- a/widgets/comiclist-dropdown.php
+++ b/widgets/comiclist-dropdown.php
@@ -83,8 +83,8 @@ class ceo_comic_list_dropdown_widget extends WP_Widget {
 	
 	function update($new_instance, $old_instance) {
 		$instance = $old_instance;
-		$instance['title'] = strip_tags($new_instance['title']);
-		$instance['exclude'] = strip_tags($new_instance['exclude']);
+		$instance['title'] = wp_strip_all_tags($new_instance['title']);
+		$instance['exclude'] = wp_strip_all_tags($new_instance['exclude']);
 		return $instance;
 	}
 	
@@ -93,7 +93,7 @@ class ceo_comic_list_dropdown_widget extends WP_Widget {
 		$title = $instance['title'];
 		$exclude = $instance['exclude'];
 		?>
-		<p><label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:','comiceasel'); ?> <input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_html_e('Title:','comiceasel'); ?> <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
 		</p>
 		<?php
 	}

--- a/widgets/navigation.php
+++ b/widgets/navigation.php
@@ -124,7 +124,7 @@ class ceo_comic_navigation_widget extends WP_Widget {
 		}
 		do_action('inside-comic-navigation');
 		if ($instance['comments']) { ?>
-			<a href="<?php the_permalink(); ?>#comments" class="navi navi-comments" title="<?php echo esc_attr($instance['comments_title']); ?>"><span class="navi-comments-count"><?php echo get_comments_number(); ?></span><?php echo esc_html($instance['comments_title']); ?></a>
+			<a href="<?php the_permalink(); ?>#comments" class="navi navi-comments" title="<?php echo esc_attr($instance['comments_title']); ?>"><span class="navi-comments-count"><?php echo esc_html(get_comments_number()); ?></span><?php echo esc_html($instance['comments_title']); ?></a>
 		<?php } ?>
 		</td>
 		<td class="comic_navi_right">
@@ -180,7 +180,7 @@ class ceo_comic_navigation_widget extends WP_Widget {
 			$thumbnail = wp_get_attachment_image_src( $post_image_id, 'full', false);
 			if (is_array($thumbnail) && !empty($thumbnail)) { 
 				$thumbnail = reset($thumbnail);
-				echo '<span class="comic-navi-href-info">'.__('Image URL (for hotlinking/embedding):','comiceasel').'&nbsp;'.esc_url($thumbnail).'</span>';
+				echo '<span class="comic-navi-href-info">'.esc_html__('Image URL (for hotlinking/embedding):','comiceasel').'&nbsp;'.esc_url($thumbnail).'</span>';
 			}
 			?>
 			</td>
@@ -298,70 +298,70 @@ class ceo_comic_navigation_widget extends WP_Widget {
 					'buycomic_title' => __('Buy!', 'comiceasel')
 					));
 		?>
-		<input id="<?php echo $this->get_field_id('first'); ?>" name="<?php echo $this->get_field_name('first'); ?>" type="checkbox" value="1" <?php checked(true, $instance['first']); ?> /> <label for="<?php echo $this->get_field_id('first'); ?>"><strong><?php _e('First','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('first_title'); ?>" name="<?php echo $this->get_field_name('first_title'); ?>" type="text" value="<?php echo esc_attr($instance['first_title']); ?>" /><br /> 
+		<input id="<?php echo esc_attr($this->get_field_id('first')); ?>" name="<?php echo esc_attr($this->get_field_name('first')); ?>" type="checkbox" value="1" <?php checked(true, $instance['first']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('first')); ?>"><strong><?php esc_html_e('First','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('first_title')); ?>" name="<?php echo esc_attr($this->get_field_name('first_title')); ?>" type="text" value="<?php echo esc_attr($instance['first_title']); ?>" /><br /> 
 		<br />
 
-		<input id="<?php echo $this->get_field_id('last'); ?>" name="<?php echo $this->get_field_name('last'); ?>" type="checkbox" value="1" <?php checked(true, $instance['last']); ?> /> <label for="<?php echo $this->get_field_id('last'); ?>"><strong><?php _e('Last','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('last_title'); ?>" name="<?php echo $this->get_field_name('last_title'); ?>" type="text" value="<?php echo esc_attr($instance['last_title']); ?>" /><br />
+		<input id="<?php echo esc_attr($this->get_field_id('last')); ?>" name="<?php echo esc_attr($this->get_field_name('last')); ?>" type="checkbox" value="1" <?php checked(true, $instance['last']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('last')); ?>"><strong><?php esc_html_e('Last','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('last_title')); ?>" name="<?php echo esc_attr($this->get_field_name('last_title')); ?>" type="text" value="<?php echo esc_attr($instance['last_title']); ?>" /><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('previous'); ?>" name="<?php echo $this->get_field_name('previous'); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous']); ?> /> <label for="<?php echo $this->get_field_id('previous'); ?>"><strong><?php _e('Previous','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('previous_title'); ?>" name="<?php echo $this->get_field_name('previous_title'); ?>" type="text" value="<?php echo esc_attr($instance['previous_title']); ?>" /><br />
+		<input id="<?php echo esc_attr($this->get_field_id('previous')); ?>" name="<?php echo esc_attr($this->get_field_name('previous')); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('previous')); ?>"><strong><?php esc_html_e('Previous','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('previous_title')); ?>" name="<?php echo esc_attr($this->get_field_name('previous_title')); ?>" type="text" value="<?php echo esc_attr($instance['previous_title']); ?>" /><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('next'); ?>" name="<?php echo $this->get_field_name('next'); ?>" type="checkbox" value="1" <?php checked(true, $instance['next']); ?> /> <label for="<?php echo $this->get_field_id('next'); ?>"><strong><?php _e('Next','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('next_title'); ?>" name="<?php echo $this->get_field_name('next_title'); ?>" type="text" value="<?php echo esc_attr($instance['next_title']); ?>" /><br />
+		<input id="<?php echo esc_attr($this->get_field_id('next')); ?>" name="<?php echo esc_attr($this->get_field_name('next')); ?>" type="checkbox" value="1" <?php checked(true, $instance['next']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('next')); ?>"><strong><?php esc_html_e('Next','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('next_title')); ?>" name="<?php echo esc_attr($this->get_field_name('next_title')); ?>" type="text" value="<?php echo esc_attr($instance['next_title']); ?>" /><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('first_in'); ?>" name="<?php echo $this->get_field_name('first_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['first_in']); ?> /> <label for="<?php echo $this->get_field_id('first_in'); ?>"><strong><?php _e('First in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('first_in_title'); ?>" name="<?php echo $this->get_field_name('first_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['first_in_title']); ?>" /><br />   
+		<input id="<?php echo esc_attr($this->get_field_id('first_in')); ?>" name="<?php echo esc_attr($this->get_field_name('first_in')); ?>" type="checkbox" value="1" <?php checked(true, $instance['first_in']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('first_in')); ?>"><strong><?php esc_html_e('First in Chapter','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('first_in_title')); ?>" name="<?php echo esc_attr($this->get_field_name('first_in_title')); ?>" type="text" value="<?php echo esc_attr($instance['first_in_title']); ?>" /><br />   
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('last_in'); ?>" name="<?php echo $this->get_field_name('last_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['last_in']); ?> /> <label for="<?php echo $this->get_field_id('last_in'); ?>"><strong><?php _e('Last in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('last_in_title'); ?>" name="<?php echo $this->get_field_name('last_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['last_in_title']); ?>" /><br />
+		<input id="<?php echo esc_attr($this->get_field_id('last_in')); ?>" name="<?php echo esc_attr($this->get_field_name('last_in')); ?>" type="checkbox" value="1" <?php checked(true, $instance['last_in']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('last_in')); ?>"><strong><?php esc_html_e('Last in Chapter','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('last_in_title')); ?>" name="<?php echo esc_attr($this->get_field_name('last_in_title')); ?>" type="text" value="<?php echo esc_attr($instance['last_in_title']); ?>" /><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('previous_in'); ?>" name="<?php echo $this->get_field_name('previous_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous_in']); ?> /> <label for="<?php echo $this->get_field_id('previous_in'); ?>"><strong><?php _e('Previous in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('previous_in_title'); ?>" name="<?php echo $this->get_field_name('previous_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['previous_in_title']); ?>" /><br />   
+		<input id="<?php echo esc_attr($this->get_field_id('previous_in')); ?>" name="<?php echo esc_attr($this->get_field_name('previous_in')); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous_in']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('previous_in')); ?>"><strong><?php esc_html_e('Previous in Chapter','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('previous_in_title')); ?>" name="<?php echo esc_attr($this->get_field_name('previous_in_title')); ?>" type="text" value="<?php echo esc_attr($instance['previous_in_title']); ?>" /><br />   
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('next_in'); ?>" name="<?php echo $this->get_field_name('next_in'); ?>" type="checkbox" value="1" <?php checked(true, $instance['next_in']); ?> /> <label for="<?php echo $this->get_field_id('next_in'); ?>"><strong><?php _e('Next in Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('next_in_title'); ?>" name="<?php echo $this->get_field_name('next_in_title'); ?>" type="text" value="<?php echo esc_attr($instance['next_in_title']); ?>" /><br />
+		<input id="<?php echo esc_attr($this->get_field_id('next_in')); ?>" name="<?php echo esc_attr($this->get_field_name('next_in')); ?>" type="checkbox" value="1" <?php checked(true, $instance['next_in']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('next_in')); ?>"><strong><?php esc_html_e('Next in Chapter','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('next_in_title')); ?>" name="<?php echo esc_attr($this->get_field_name('next_in_title')); ?>" type="text" value="<?php echo esc_attr($instance['next_in_title']); ?>" /><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('previous_chap'); ?>" name="<?php echo $this->get_field_name('previous_chap'); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous_chap']); ?> /> <label for="<?php echo $this->get_field_id('previous_chap'); ?>"><strong><?php _e('Previous Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('previous_chap_title'); ?>" name="<?php echo $this->get_field_name('previous_chap_title'); ?>" type="text" value="<?php echo esc_attr($instance['previous_chap_title']); ?>" /><br />   
+		<input id="<?php echo esc_attr($this->get_field_id('previous_chap')); ?>" name="<?php echo esc_attr($this->get_field_name('previous_chap')); ?>" type="checkbox" value="1" <?php checked(true, $instance['previous_chap']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('previous_chap')); ?>"><strong><?php esc_html_e('Previous Chapter','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('previous_chap_title')); ?>" name="<?php echo esc_attr($this->get_field_name('previous_chap_title')); ?>" type="text" value="<?php echo esc_attr($instance['previous_chap_title']); ?>" /><br />   
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('next_chap'); ?>" name="<?php echo $this->get_field_name('next_chap'); ?>" type="checkbox" value="1" <?php checked(true, $instance['next_chap']); ?> /> <label for="<?php echo $this->get_field_id('next_chap'); ?>"><strong><?php _e('Next Chapter','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('next_chap_title'); ?>" name="<?php echo $this->get_field_name('next_chap_title'); ?>" type="text" value="<?php echo esc_attr($instance['next_chap_title']); ?>" /><br />
+		<input id="<?php echo esc_attr($this->get_field_id('next_chap')); ?>" name="<?php echo esc_attr($this->get_field_name('next_chap')); ?>" type="checkbox" value="1" <?php checked(true, $instance['next_chap']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('next_chap')); ?>"><strong><?php esc_html_e('Next Chapter','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('next_chap_title')); ?>" name="<?php echo esc_attr($this->get_field_name('next_chap_title')); ?>" type="text" value="<?php echo esc_attr($instance['next_chap_title']); ?>" /><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('comictitle'); ?>" name="<?php echo $this->get_field_name('comictitle'); ?>" type="checkbox" value="1" <?php checked(true, $instance['comictitle']); ?> /> <label for="<?php echo $this->get_field_id('comictitle'); ?>"><strong><?php _e('Comic Title','comiceasel'); ?></strong></label>
+		<input id="<?php echo esc_attr($this->get_field_id('comictitle')); ?>" name="<?php echo esc_attr($this->get_field_name('comictitle')); ?>" type="checkbox" value="1" <?php checked(true, $instance['comictitle']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('comictitle')); ?>"><strong><?php esc_html_e('Comic Title','comiceasel'); ?></strong></label>
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('comicchapter'); ?>" name="<?php echo $this->get_field_name('comicchapter'); ?>" type="checkbox" value="1" <?php checked(true, $instance['comicchapter']); ?> /> <label for="<?php echo $this->get_field_id('comicchapter'); ?>"><strong><?php _e('Comic Chapter','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('comicchapter')); ?>" name="<?php echo esc_attr($this->get_field_name('comicchapter')); ?>" type="checkbox" value="1" <?php checked(true, $instance['comicchapter']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('comicchapter')); ?>"><strong><?php esc_html_e('Comic Chapter','comiceasel'); ?></strong></label><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('archives'); ?>" name="<?php echo $this->get_field_name('archives'); ?>" type="checkbox" value="1" <?php checked(true, $instance['archives']); ?> /> <label for="<?php echo $this->get_field_id('archives'); ?>"><strong><?php _e('Archives','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('archives_title'); ?>" name="<?php echo $this->get_field_name('archives_title'); ?>" type="text" value="<?php echo esc_attr($instance['archives_title']); ?>" /><br />   
-		Archive URL: <input class="widefat" id="<?php echo $this->get_field_id('archive_path'); ?>" name="<?php echo $this->get_field_name('archive_path'); ?>" type="text" value="<?php echo esc_attr($instance['archive_path']); ?>" /><br />
+		<input id="<?php echo esc_attr($this->get_field_id('archives')); ?>" name="<?php echo esc_attr($this->get_field_name('archives')); ?>" type="checkbox" value="1" <?php checked(true, $instance['archives']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('archives')); ?>"><strong><?php esc_html_e('Archives','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('archives_title')); ?>" name="<?php echo esc_attr($this->get_field_name('archives_title')); ?>" type="text" value="<?php echo esc_attr($instance['archives_title']); ?>" /><br />   
+		Archive URL: <input class="widefat" id="<?php echo esc_attr($this->get_field_id('archive_path')); ?>" name="<?php echo esc_attr($this->get_field_name('archive_path')); ?>" type="text" value="<?php echo esc_attr($instance['archive_path']); ?>" /><br />
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('comments'); ?>" name="<?php echo $this->get_field_name('comments'); ?>" type="checkbox" value="1" <?php checked(true, $instance['comments']); ?> /> <label for="<?php echo $this->get_field_id('comments'); ?>"><strong><?php _e('Comments','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('comments_title'); ?>" name="<?php echo $this->get_field_name('comments_title'); ?>" type="text" value="<?php echo esc_attr($instance['comments_title']); ?>" /><br />   
+		<input id="<?php echo esc_attr($this->get_field_id('comments')); ?>" name="<?php echo esc_attr($this->get_field_name('comments')); ?>" type="checkbox" value="1" <?php checked(true, $instance['comments']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('comments')); ?>"><strong><?php esc_html_e('Comments','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('comments_title')); ?>" name="<?php echo esc_attr($this->get_field_name('comments_title')); ?>" type="text" value="<?php echo esc_attr($instance['comments_title']); ?>" /><br />   
 		<br />
 		
-		<input id="<?php echo $this->get_field_id('random'); ?>" name="<?php echo $this->get_field_name('random'); ?>" type="checkbox" value="1" <?php checked(true, $instance['random']); ?> /> <label for="<?php echo $this->get_field_id('random'); ?>"><strong><?php _e('Random','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('random_title'); ?>" name="<?php echo $this->get_field_name('random_title'); ?>" type="text" value="<?php echo esc_attr($instance['random_title']); ?>" /><br />   
+		<input id="<?php echo esc_attr($this->get_field_id('random')); ?>" name="<?php echo esc_attr($this->get_field_name('random')); ?>" type="checkbox" value="1" <?php checked(true, $instance['random']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('random')); ?>"><strong><?php esc_html_e('Random','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('random_title')); ?>" name="<?php echo esc_attr($this->get_field_name('random_title')); ?>" type="text" value="<?php echo esc_attr($instance['random_title']); ?>" /><br />   
 		<br />
 <?php if (ceo_pluginfo('enable_buy_comic')) { ?>
-		<input id="<?php echo $this->get_field_id('buycomic'); ?>" name="<?php echo $this->get_field_name('buycomic'); ?>" type="checkbox" value="1" <?php checked(true, $instance['buycomic']); ?> /> <label for="<?php echo $this->get_field_id('buycomic'); ?>"><strong><?php _e('Buy!','comiceasel'); ?></strong></label><br />
-		<input id="<?php echo $this->get_field_id('buycomic_title'); ?>" name="<?php echo $this->get_field_name('buycomic_title'); ?>" type="text" value="<?php echo esc_attr($instance['buycomic_title']); ?>" /><br />   
+		<input id="<?php echo esc_attr($this->get_field_id('buycomic')); ?>" name="<?php echo esc_attr($this->get_field_name('buycomic')); ?>" type="checkbox" value="1" <?php checked(true, $instance['buycomic']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('buycomic')); ?>"><strong><?php esc_html_e('Buy!','comiceasel'); ?></strong></label><br />
+		<input id="<?php echo esc_attr($this->get_field_id('buycomic_title')); ?>" name="<?php echo esc_attr($this->get_field_name('buycomic_title')); ?>" type="text" value="<?php echo esc_attr($instance['buycomic_title']); ?>" /><br />   
 		<br />
 <?php } ?>		
-		<input id="<?php echo $this->get_field_id('imageurl'); ?>" name="<?php echo $this->get_field_name('imageurl'); ?>" type="checkbox" value="1" <?php checked(true, $instance['imageurl']); ?> /> <label for="<?php echo $this->get_field_id('imageurl'); ?>"><strong><?php _e('ImageURL','comiceasel'); ?></strong></label>
+		<input id="<?php echo esc_attr($this->get_field_id('imageurl')); ?>" name="<?php echo esc_attr($this->get_field_name('imageurl')); ?>" type="checkbox" value="1" <?php checked(true, $instance['imageurl']); ?> /> <label for="<?php echo esc_attr($this->get_field_id('imageurl')); ?>"><strong><?php esc_html_e('ImageURL','comiceasel'); ?></strong></label>
 		<?php
 	}
 }

--- a/widgets/recentcomics.php
+++ b/widgets/recentcomics.php
@@ -46,19 +46,19 @@ class ceo_latest_comics_widget extends WP_Widget {
 	
 	function update($new_instance, $old_instance) {
 		$instance = $old_instance;
-		$instance['title'] = strip_tags($new_instance['title']);
+		$instance['title'] = wp_strip_all_tags($new_instance['title']);
 		$instance['count'] = (int)$new_instance['count'];
 		return $instance;
 	}
 	
 	function form($instance) {
 		$instance = wp_parse_args( (array) $instance, array( 'title' => '', 'count' => 5 ) );
-		$title = strip_tags($instance['title']);
+		$title = wp_strip_all_tags($instance['title']);
 		$count = (int)$instance['count'];
 		if (($count > 50) || ($count < 1)) $count = 5;
 		?>
-		<p><label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:','comiceasel'); ?> <input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
-		<p><label for="<?php echo $this->get_field_id('count'); ?>"><?php _e('Display Amount (1-50):','comiceasel'); ?> <input class="widefat" id="<?php echo $this->get_field_id('count'); ?>" name="<?php echo $this->get_field_name('count'); ?>" type="text" value="<?php echo esc_attr($count); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_html_e('Title:','comiceasel'); ?> <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('count')); ?>"><?php esc_html_e('Display Amount (1-50):','comiceasel'); ?> <input class="widefat" id="<?php echo esc_attr($this->get_field_id('count')); ?>" name="<?php echo esc_attr($this->get_field_name('count')); ?>" type="text" value="<?php echo esc_attr($count); ?>" /></label></p>
 		<?php
 	}
 }

--- a/widgets/scheduledcomics.php
+++ b/widgets/scheduledcomics.php
@@ -37,7 +37,7 @@ class ceo_scheduled_comics_widget extends WP_Widget {
 				);
 		$scheduled_posts = get_posts($args);
 		if (empty($scheduled_posts)) {
-			echo '<ul><li>'.__('None','comiceasel').'</li></ul>';
+			echo '<ul><li>'.esc_html__('None','comiceasel').'</li></ul>';
 		} else { ?>
 			<ul>
 			<?php foreach($scheduled_posts as $post) : ?>
@@ -51,15 +51,15 @@ class ceo_scheduled_comics_widget extends WP_Widget {
 	
 	function update($new_instance, $old_instance) {
 		$instance = $old_instance;
-		$instance['title'] = strip_tags($new_instance['title']);
+		$instance['title'] = wp_strip_all_tags($new_instance['title']);
 		return $instance;
 	}
 	
 	function form($instance) {
 		$instance = wp_parse_args( (array) $instance, array( 'title' => '' ) );
-		$title = strip_tags($instance['title']);
+		$title = wp_strip_all_tags($instance['title']);
 		?>
-		<p><label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:','comiceasel'); ?> <input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_html_e('Title:','comiceasel'); ?> <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
 		<?php
 	}
 }

--- a/widgets/thumbnail.php
+++ b/widgets/thumbnail.php
@@ -68,14 +68,14 @@ class ceo_thumbnail_widget extends WP_Widget {
 							if ( has_post_thumbnail($post->ID) ) {
 								echo '<a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.esc_attr(__('Permanent Link to','comiceasel').' '.get_the_title()).'">'.get_the_post_thumbnail($post->ID, $thumbnail_size).'</a>'."\r\n";
 							} else {
-								echo __('No Thumbnail Found.','comiceasel');	
+								echo esc_html__('No Thumbnail Found.','comiceasel');	
 							}							
 						}
 					} else {
 						if ( has_post_thumbnail($post->ID) ) {
 							echo '<a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.esc_attr(__('Permanent Link to','comiceasel').' '.get_the_title()).'">'.get_the_post_thumbnail($post->ID, $thumbnail_size).'</a>'."\r\n";
 						} else {
-							echo __('No Thumbnail Found.','comiceasel');	
+							echo esc_html__('No Thumbnail Found.','comiceasel');	
 						}
 					}
 					if ($instance['linktitle']) { echo '<div class="comic-thumb-title"><a href="'.esc_url($the_permalink).'" rel="bookmark" title="'.esc_attr(__('Permanent Link to','comiceasel').' '.get_the_title()).'">'.ceo_title_for_html($post->ID).'</a></div><div class="clear"></div>'; }
@@ -91,10 +91,10 @@ class ceo_thumbnail_widget extends WP_Widget {
 	
 	function update($new_instance, $old_instance) {
 		$instance = $old_instance;
-		$instance['title'] = strip_tags($new_instance['title']);
-		$instance['thumbnail_size'] = strip_tags($new_instance['thumbnail_size']);
-		$instance['thumbchapt'] = strip_tags($new_instance['thumbchapt']);
-		$instance['thumbcount'] = (int)strip_tags($new_instance['thumbcount']);
+		$instance['title'] = wp_strip_all_tags($new_instance['title']);
+		$instance['thumbnail_size'] = wp_strip_all_tags($new_instance['thumbnail_size']);
+		$instance['thumbchapt'] = wp_strip_all_tags($new_instance['thumbchapt']);
+		$instance['thumbcount'] = (int)wp_strip_all_tags($new_instance['thumbcount']);
 		$instance['first'] =  (bool)( $new_instance['first'] == 1 ? true : false );
 		$instance['random'] =  (bool)( $new_instance['random'] == 1 ? true : false );
 		$instance['linktitle'] = (bool)($new_instance['linktitle'] == 1 ? true : false );
@@ -108,7 +108,7 @@ class ceo_thumbnail_widget extends WP_Widget {
 	
 	function form($instance) {
 		$instance = wp_parse_args( (array) $instance, array( 'title' => '', 'thumbchapt' => '', 'first' => false, 'random' => false, 'thumbcount' => 1, 'linktitle' => false, 'centering' => false, 'showdate' => false, 'secondary' => false, 'same' => false, 'inhistory' => false, 'thumbnail_size' => 'thumbnail' ) );
-		$title = strip_tags($instance['title']);
+		$title = wp_strip_all_tags($instance['title']);
 		$thumbnail_size = (isset($instance['thumbnail_size'])) ? $instance['thumbnail_size'] : 'thumbnail';
 		$thumbchapt = $instance['thumbchapt'];
 		$first = $instance['first'];
@@ -121,9 +121,9 @@ class ceo_thumbnail_widget extends WP_Widget {
 		$same = $instance['same'];
 		$inhistory = $instance['inhistory'];
 		?>
-		<p><label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:', 'comiceasel'); ?> <input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
-		<p><label for="<?php echo $this->get_field_id('thumbnail_size'); ?>"><?php _e('Thumbnail size to use:','comiceasel'); ?></label>
-		<select name="<?php echo $this->get_field_name('thumbnail_size'); ?>" id="<?php echo $this->get_field_id('thumbnail_size'); ?>">
+		<p><label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php esc_html_e('Title:', 'comiceasel'); ?> <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($title); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('thumbnail_size')); ?>"><?php esc_html_e('Thumbnail size to use:','comiceasel'); ?></label>
+		<select name="<?php echo esc_attr($this->get_field_name('thumbnail_size')); ?>" id="<?php echo esc_attr($this->get_field_id('thumbnail_size')); ?>">
 		<?php 
 			$thumbnail_sizes = get_intermediate_image_sizes();
 			foreach ($thumbnail_sizes as $size) { ?>
@@ -131,7 +131,7 @@ class ceo_thumbnail_widget extends WP_Widget {
 		<?php } ?>
 			<option class="level-0" value="full" <?php selected($thumbnail_size, 'full'); ?>><?php esc_html_e('Full', 'comiceasel'); ?></option>
 		</select></p>
-		<p><?php _e('Which Chapter?', 'comiceasel'); ?><br />	
+		<p><?php esc_html_e('Which Chapter?', 'comiceasel'); ?><br />	
 		<?php 
 		
 		$allterms = &get_terms('chapters');
@@ -145,22 +145,22 @@ class ceo_thumbnail_widget extends WP_Widget {
 				$chapter_options .= '<option name="'.esc_attr($term->slug).'" value="'.esc_attr($term->slug).'" '.$chaptselected.'> '.esc_html($term->name).' </option>';
 			}
 			?>
-			<select name="<?php echo $this->get_field_name('thumbchapt'); ?>" id="<?php echo $this->get_field_id('thumbchapt'); ?>">
+			<select name="<?php echo esc_attr($this->get_field_name('thumbchapt')); ?>" id="<?php echo esc_attr($this->get_field_id('thumbchapt')); ?>">
 			<?php echo $chapter_options; ?>
 			</select>
 		<?php } ?>
 		</p>
-		<p><label for="<?php echo $this->get_field_id('first'); ?>"><?php _e('Get first in chapter instead?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('first'); ?>" name="<?php echo $this->get_field_name('first'); ?>" type="checkbox" value="1" <?php checked(true, $first); ?> /></label></p>		
-		<p><label for="<?php echo $this->get_field_id('random'); ?>"><?php _e('Display a random Thumbnail?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('random'); ?>" name="<?php echo $this->get_field_name('random'); ?>" type="checkbox" value="1" <?php checked(true, $random); ?> /></label></p>
-		<p><em><?php _e('*note: Random thumbnail overrides the get first in chapter option.','comiceasel'); ?></em></p>
-		<p><?php esc_html_e('Display how many thumbnails?', 'comiceasel'); ?><input style="width:40px;" id="<?php echo $this->get_field_id('thumbcount'); ?>" name="<?php echo $this->get_field_name('thumbcount'); ?>" type="text" value="<?php echo esc_attr(stripcslashes($instance['thumbcount'])); ?>" /></label></p>
-		<p><label for="<?php echo $this->get_field_id('linktitle'); ?>"><?php _e('Include comic title?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('linktitle'); ?>" name="<?php echo $this->get_field_name('linktitle'); ?>" type="checkbox" value="1" <?php checked(true, $linktitle); ?> /></label></p>
-		<p><label for="<?php echo $this->get_field_id('centering'); ?>"><?php _e('Add centering html?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('centering'); ?>" name="<?php echo $this->get_field_name('centering'); ?>" type="checkbox" value="1" <?php checked(true, $centering); ?> /></label></p>
-		<p><label for="<?php echo $this->get_field_id('showdate'); ?>"><?php _e('Show the date of the post under image?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('showdate'); ?>" name="<?php echo $this->get_field_name('showdate'); ?>" type="checkbox" value="1" <?php checked(true, $showdate); ?> /></label></p>
-		<p><label for="<?php echo $this->get_field_id('secondary'); ?>"><?php _e('Use Secondary Image if plugin active?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('secondary'); ?>" name="<?php echo $this->get_field_name('secondary'); ?>" type="checkbox" value="1" <?php checked(true, $secondary); ?> /></label></p>		
-		<p><label for="<?php echo $this->get_field_id('same'); ?>"><?php _e('Disable thumbnail from showing on same page the comic in the thumbnail displays?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('same'); ?>" name="<?php echo $this->get_field_name('same'); ?>" type="checkbox" value="1" <?php checked(true, $same); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('first')); ?>"><?php esc_html_e('Get first in chapter instead?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('first')); ?>" name="<?php echo esc_attr($this->get_field_name('first')); ?>" type="checkbox" value="1" <?php checked(true, $first); ?> /></label></p>		
+		<p><label for="<?php echo esc_attr($this->get_field_id('random')); ?>"><?php esc_html_e('Display a random Thumbnail?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('random')); ?>" name="<?php echo esc_attr($this->get_field_name('random')); ?>" type="checkbox" value="1" <?php checked(true, $random); ?> /></label></p>
+		<p><em><?php esc_html_e('*note: Random thumbnail overrides the get first in chapter option.','comiceasel'); ?></em></p>
+		<p><?php esc_html_e('Display how many thumbnails?', 'comiceasel'); ?><input style="width:40px;" id="<?php echo esc_attr($this->get_field_id('thumbcount')); ?>" name="<?php echo esc_attr($this->get_field_name('thumbcount')); ?>" type="text" value="<?php echo esc_attr(stripcslashes($instance['thumbcount'])); ?>" /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('linktitle')); ?>"><?php esc_html_e('Include comic title?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('linktitle')); ?>" name="<?php echo esc_attr($this->get_field_name('linktitle')); ?>" type="checkbox" value="1" <?php checked(true, $linktitle); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('centering')); ?>"><?php esc_html_e('Add centering html?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('centering')); ?>" name="<?php echo esc_attr($this->get_field_name('centering')); ?>" type="checkbox" value="1" <?php checked(true, $centering); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('showdate')); ?>"><?php esc_html_e('Show the date of the post under image?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('showdate')); ?>" name="<?php echo esc_attr($this->get_field_name('showdate')); ?>" type="checkbox" value="1" <?php checked(true, $showdate); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('secondary')); ?>"><?php esc_html_e('Use Secondary Image if plugin active?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('secondary')); ?>" name="<?php echo esc_attr($this->get_field_name('secondary')); ?>" type="checkbox" value="1" <?php checked(true, $secondary); ?> /></label></p>		
+		<p><label for="<?php echo esc_attr($this->get_field_id('same')); ?>"><?php esc_html_e('Disable thumbnail from showing on same page the comic in the thumbnail displays?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('same')); ?>" name="<?php echo esc_attr($this->get_field_name('same')); ?>" type="checkbox" value="1" <?php checked(true, $same); ?> /></label></p>
 		<hr />
-		<p><label for="<?php echo $this->get_field_id('inhistory'); ?>"><?php _e('This date in history?','comiceasel'); ?> <input id="<?php echo $this->get_field_id('inhistory'); ?>" name="<?php echo $this->get_field_name('inhistory'); ?>" type="checkbox" value="1" <?php checked(true, $inhistory); ?> /></label></p>
+		<p><label for="<?php echo esc_attr($this->get_field_id('inhistory')); ?>"><?php esc_html_e('This date in history?','comiceasel'); ?> <input id="<?php echo esc_attr($this->get_field_id('inhistory')); ?>" name="<?php echo esc_attr($this->get_field_name('inhistory')); ?>" type="checkbox" value="1" <?php checked(true, $inhistory); ?> /></label></p>
 		<br />
 	<?php
 	}


### PR DESCRIPTION
Follows #49, which has now merged.

Mechanical pass over Plugin Check's escaping findings, limited to the classes that keep rendered output identical:

- `_e()` / `echo __()` → `esc_html_e()` / `esc_attr_e()` by context; strings carrying HTML entities are left as-is, since `esc_html()`/`esc_attr()` do not double-encode, so glyphs are unchanged
- Widget form field ids/names wrapped in `esc_attr()`
- `strip_tags()` → `wp_strip_all_tags()`; legacy `get_terms()` positional args → array form
- Small i18n fixes: missing text domain, translators comments, HTML moved out of translatable strings

Deliberately left: `date()`, direct queries, `wp_reset_query()`, redirects, and filter-wrapped or helper-escaped output, where a change could alter behavior on existing sites. PHPCS (security ruleset): 536 → 72 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)